### PR TITLE
v0.0.3-alpha.1 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # go-stackage
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/JesseCoretta/go-stackage)](https://goreportcard.com/report/github.com/JesseCoretta/go-stackage) [![GoDoc](https://godoc.org/github.com/JesseCoretta/go-stackage?status.svg)](https://godoc.org/github.com/JesseCoretta/go-stackage) ![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)
+[![Go Report Card](https://goreportcard.com/badge/github.com/JesseCoretta/go-stackage)](https://goreportcard.com/report/github.com/JesseCoretta/go-stackage) [![GoDoc](https://godoc.org/github.com/JesseCoretta/go-stackage?status.svg)](https://godoc.org/github.com/JesseCoretta/go-stackage) ![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/JesseCoretta/go-stackage/issues) ![Static Badge](https://img.shields.io/badge/experimental-red?logo=simple-icons&labelColor=purple&color=maroon&link=https%3A%2F%2Fgithub.com%2FJesseCoretta%2Fgo-stackage)
 
 Package stackage implements a flexible Stack type with useful features.

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,3 @@
+## Examples
+
+This areas contains example demos submitted by the community, or written by the maintainer(s).

--- a/_examples/main_netstack_readwrite.go
+++ b/_examples/main_netstack_readwrite.go
@@ -1,0 +1,1106 @@
+package main
+
+/*
+netstack - demonstrate a basic RESTful JSON interface
+to an aliased Stack type instance with GET, DELETE and
+POST capabilities.
+
+This demo aims to extol as many of the (relevant)
+features and capabilities of this package in a manner
+most people can relate to.
+*/
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/JesseCoretta/go-stackage"
+)
+
+/*
+APIRoot is the absolute root context for all API-related
+resources. Changing this will result in a change of the
+"/api" path element in all URLs throughout this example.
+*/
+const APIRoot = `/api`
+
+/*
+APIDefault defines the default API branch/context. This
+is used in redirects in the event the user requests the
+APIRoot URL without specifying a branch.
+*/
+const APIDefault = APIRoot + `/v1`
+
+/*
+MyStack is a type alias for the stackage.Stack type.
+
+For simplicity, the only methods extended through this
+type pertain to the intentions of this demo. We have NOT
+extended ALL of stackage.Stack's many methods. Had this
+occurred, the demo would be significantly larger for no
+good reason.
+
+However, we are able to ACCESS those methods by simply
+type-casting MyStack->Stack.  For example, to access the
+Len method in a MyStack instance:
+
+  var mystack MyStack // assume this has been populated with something
+  fmt.Printf("Length of %T: %d", mystack, stackage.Stack(mystack).Len())
+  // Output: Length of main.MyStack: 2
+
+Note that when we cast mystack within Stack, we're accessing
+the underlying embedded pointer instance. If we need to make
+changes to the instance, we need not worry about "writing any
+changes back" to the instance of MyStack -- the pointer data
+will reflect the changes, regardless of what type the pointer
+instance is enveloped within.
+*/
+type MyStack stackage.Stack
+
+/*
+MyMuX is a single container in which we shall
+store our HTTP listener.
+
+This is largely for convenience, and is hardly
+the only option. One could conceivably put the
+contents in their own Auxiliary key/value pair
+and do it that way.
+*/
+type MyMuX struct{
+	*http.Server
+	*http.ServeMux
+}
+
+/*
+updateInfo contains a payload intended to alter
+the served stack structure in some way, for
+instance 'remove', 'insert', and others.
+
+It would be delivered via a command such as
+
+  curl -X POST <scheme://addr> -d '<this_type_marshaled_as_json_bytes>'
+*/
+type updateInfo struct {
+       Action  string	      `json:"action"`		 // the stackage method name, such as 'insert' (case not important)
+       Method  string	      `json:"-"`		 // typically POST or DELETE, not set by user explicitly, not visible in JSON
+       Parameters map[string]any `json:"parameters,omitempty"` // input params required by various stackage.Stack methods
+}
+
+/*
+slice is the abstraction of any particular
+slice value within a stack.
+*/
+type slice struct{
+        Type     string	`json:"type"`
+	ID       string `json:"identifier,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+	Category string `json:"category,omitempty"`
+	Capacity int    `json:"capacity,omitempty"`
+	Length   int    `json:"length,omitempty"`
+        Index    int	`json:"index"`
+	Nesting  bool	`json:"nesting,omitempty"`
+	ReadOnly bool	`json:"readonly,omitempty"`
+	FIFO     bool   `json:"fifo,omitempty"`
+        Value    any	`json:"value"`
+}
+
+/*
+our main function executes all of the top-level
+processing actions, variable assembly, etc., and
+launches a listener. This is a microcosm for your
+hypothetical app, in essence.
+*/
+func main() {
+	log.SetFlags(0)
+        stackage.SetDefaultStackLogLevel(`ALL`)
+        stackage.SetDefaultStackLogger(`stdout`)
+
+        stackage.SetDefaultConditionLogLevel(`ALL`)
+        stackage.SetDefaultConditionLogger(`stdout`)
+
+	// create signal channel to gracefully
+	// receive CTRL+C (^C) sequences. Note
+	// this is an UNBUFFERED channel that
+	// will block on the first signal it
+	// receives.
+	quit := make(chan os.Signal)
+	signal.Notify(quit, os.Interrupt)
+
+	// Load our pre-designed stack (MakeStack)
+	// and initialize (but not execute) our
+	// HTTP ServeMux/Server instances, with
+	// support for listening on ALL local
+	// addresses via TCP/8080.
+	stack := MakeStack().SetListener(":8080")
+	go func() {
+		// Execute our listener and feed
+		// it our signal channel.
+		stack.Listen(quit)
+	}()
+
+	// BLOCK: do NOT close out ...
+	<-quit
+
+	// ... until you receive a signal, at which
+	// point, shutdown gracefully (Shutdown) by
+	// feeding it a background Context instance.
+	ctx, cancel := context.WithTimeout(context.Background(), 60 * time.Second)
+	defer cancel()
+	if err := stack.Shutdown(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+/*
+MakeStack is simply an assembly function for data
+to serve. Note this data is quite illogical and
+serves only to provide content for the sake of
+content. Ideally a user would fill this with some
+kind of meaningful data.
+
+Note that we CAST every stackage.Stack instance
+as MyStack. Strictly speaking, its not required. One
+can easily just *use* the Stack type as opposed to
+creating a custom derivative type. In this demo,
+however, we are using a custom type so that we can
+extend various demo-related methods for simplicity
+(such as Shutdown, Listen, SetListener, et al).
+
+We also CAST Stack instances so that we can access
+its myriad methods without having to manually write
+wrapper to extend them piecemeal.
+*/
+func MakeStack() MyStack {
+	var basicValues []any = []any{
+		'L', 'x', '#', '🤣', rune(59), '临', '亶', 'ヨ', '⊕',
+	}
+
+	// top level of structure (r) is
+	// returned as MyStack instance.
+	r := MyStack(stackage.List().SetID(`netstack`).Push(
+		MyStack(stackage.Basic().SetID(`_random`).Push(basicValues...)),
+		MyStack(stackage.And().SetID(`_addr`).Push(
+			`blue`,
+			`red`,
+			`green`,
+		)),
+		MyStack(stackage.And().SetID(`_random`).Push(
+			MyStack(stackage.Or().SetID(`_random`).Push(
+				stackage.Cond(`name`,stackage.Eq,`Mike`),
+				stackage.Cond(`name`,stackage.Eq,`Courtney`),
+			)),
+			MyStack(stackage.Not().SetID(`negations`).Push(
+				MyStack(stackage.Or(4).SetID(`or_negation`).Push(
+					stackage.Cond(`terminated`,stackage.Eq,true),
+					stackage.Cond(`disgruntled`,stackage.Eq,true),
+				)),
+			)),
+		)),
+	))
+
+	return r
+}
+
+/*
+Listen is a custom method extended through instances of the MyStack
+type.
+
+Listen shall launch the underlying *http.Server instance's listener
+method (ListenAndServe) and serve the API as defined. An error is
+returned when the process terminates or is terminated. The input
+channel instance (stop) shall allow graceful intercept of CTRL+C
+(^C) input signals, allowing the Server thread to *properly* close
+down, as opposed to being clobbered into oblivion.
+*/
+func (r MyStack) Listen(stop chan os.Signal) (err error) {
+	srv := r.Server()
+	log.Printf("%s: listening on %s ... \n",
+		stackage.Stack(r).ID(), srv.Addr)
+
+	return r.Server().ListenAndServe()
+}
+
+/*
+Shutdown gracefully terminates the underlying *http.ServeMux and
+*http.Server listener system, returning any error resulting from
+the attempt.
+
+The context.Context input argument (ctx) is provided by the caller
+of this method, which is the main() function in this demo.
+*/
+func (r MyStack) Shutdown(ctx context.Context) (err error) {
+	log.Printf("\nReceived termination signal")
+
+        srv := r.Server()
+	if err = srv.Shutdown(ctx); err != nil {
+		return
+	}
+
+	log.Printf("%s: stopping listener on %s...\n",
+		stackage.Stack(r).ID(), srv.Addr)
+	return
+}
+
+/*
+SetListener assembles and configures the listener in
+anticipation of serving content. This method does not
+actually launch the listener.
+
+Note that this method only impacts the receiver instance
+directly. It will not create similar listener instances
+in any nested stack or stack aliases found within the
+receiver instance. Only the "top-level" or "outermost"
+stack instance requires this setup procedure.
+*/
+func (r MyStack) SetListener(addr ...string) MyStack {
+        var address string = ":8080"
+        if len(addr) > 0 {
+                address = addr[0]
+        }
+
+	// Assembly of our multiplexer
+	// and http server
+	mux := http.NewServeMux()
+	srv := &http.Server{Addr: address, Handler: mux}
+	ls := MyMuX{srv,mux}
+
+	// Pass the receiver (MyStack) into the Configure
+	// method. This creates routes and handlers used
+	// for traversal and navigation within the stack
+	// via the JSON RESTful interface.
+	ls.Configure(r)
+
+	// SetAuxiliary will initialize the underlying map
+	// instance (Auxiliary) for administrative use. In
+	// particular, it is needed to store the listener
+	// system assembled above ...
+	stackage.Stack(r).		// cast MyStack->Stack
+		SetAuxiliary().		// init map (only needed once)
+		Auxiliary().		// call map
+		Set(`listener`, ls)	// set listener instance (ls) as map value identified by key `listener`
+
+	return r
+}
+
+/*
+Handler is a convenience method that accesses the underlying admin
+map (Auxiliary) and calls the listener key/value pair. In the case
+of this method, the process is used to return the instance of the
+*http.ServeMux, which was assembled within the SetListener method.
+*/
+func (r MyStack) Handler() *http.ServeMux {
+	val, found := stackage.Stack(r).Auxiliary().Get(`listener`)
+	if !found {
+		return nil
+	}
+	return val.(MyMuX).ServeMux
+}
+
+/*
+Server is a convenience method that accesses the underlying admin
+map (Auxiliary) and calls the listener key/value pair. In the case
+of this method, the process is used to return the instance of the
+*http.Server, which was assembled within the SetListener method.
+*/
+func (r MyStack) Server() *http.Server {
+        val, found := stackage.Stack(r).Auxiliary().Get(`listener`)
+        if !found {
+                return nil
+        }
+        return val.(MyMuX).Server
+}
+
+/*
+Configure assigns redirects and handlers as needed within the receiver.
+
+Users would likely want to significantly customize this, adding
+their own paths, etc., as needed to suit their data structure.
+*/
+func (r *MyMuX) Configure(stack MyStack) MyMuX {
+
+	// Begin setting up our fundamental handlers
+        r.ServeMux.HandleFunc("/", rootHandler)					// absolute root of listener "/"
+        r.ServeMux.Handle(APIRoot,    http.RedirectHandler(APIDefault,302))	// "/api"
+        r.ServeMux.Handle(APIDefault, http.HandlerFunc(v1Handler))		// "/api/v1"
+
+	// This is an unimplemented handler, always
+	// returns HTTP 501: Not Implemented.
+	apiV2 := APIRoot + `/v2`
+        r.ServeMux.Handle(apiV2, http.HandlerFunc(v2Handler))			// "/api/v2" (dead-end)
+
+	// "/slice" by itself brings the user to
+	// the main landing page for the slice,
+	// which contains a list of available
+	// slice indices.
+        slicesPath := APIDefault + "/slice"
+        r.ServeMux.HandleFunc(slicesPath, stack.slicesHandler)
+
+	// "/slice/<N>" (e.g.: "/slice/1") will
+	// bring the user to the page for the
+	// specific slice(s) they have called.
+	// This accepts traversal paths as well
+	// as single indices. Some examples:
+	//
+	//   - /slice/1		"just return slice index 1"
+	//   - /slice/1/0/2/1	"hierarchically traverse slice indices 1->0->2 and call slice index 1"
+	//
+	// StripPrefix is used so the handler
+	// function can more easily split the
+	// path into discrete indices as shown
+	// in the above example.
+        r.ServeMux.Handle(slicesPath + `/`, http.StripPrefix(
+		slicesPath + `/`,
+		http.HandlerFunc(stack.sliceHandler),
+	))
+
+	return *r
+}
+
+/*
+ServeHTTP is used by net/http to serve content via the mux. It need
+not contain any actual code, only the signature is needed.
+*/
+func (r MyMuX) ServeHTTP(http.ResponseWriter, *http.Request) {}
+
+/*
+slicesHandler handles requests pertaining to the root slice index resource,
+in which a specific index is not requested. Instead, a manifest of available
+slice contexts is presented, allowing the visitor to select (choose) one or
+more slice indices to call.
+
+This handler allows GET, DELETE and POST methods.  GET shall render the manifest
+object, while POST shall allow the manipulation of multiple indices from the top-level
+(i.e.: remove, insert, et al). DELETE shall remove an indicated slice altogether,
+using either pop or remove, each of which operate with subtle differences).
+*/
+func (r MyStack) slicesHandler(resp http.ResponseWriter, req *http.Request) {
+	resp.Header().Set("Content-Type", "application/json")
+
+	// Make sure the client isn't requesting some
+	// inappropriate HTTP method. Only support the
+	// ones listed here, and bail on anything else.
+	if !methodAllowed(req.Method, []string{
+		http.MethodPost,
+		http.MethodGet,
+		http.MethodDelete,
+	}) {
+		http.Error(resp, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// We defined this type here because frankly it need
+	// not be globally usable.
+	type mainDirectory struct {
+		ID       string `json:"identifier,omitempty"`
+		Kind     string `json:"kind,omitempty"`
+		Category string `json:"category,omitempty"`
+		Length   int    `json:"len"`
+		Capacity int    `json:"cap,omitempty"`
+		ReadOnly bool   `json:"readonly,omitempty"`
+		Nesting  bool   `json:"nesting,omitempty"`
+		Slices []int    `json:"slices"`
+	}
+
+	// If method is POST or DELETE, just run the contents
+	// of this section and bail out. Go no further!
+	if req.Method == http.MethodDelete || req.Method == http.MethodPost {
+		if err := r.deleteOrPost(resp, req); err != nil {
+			// tell the ADMIN by console msg (optional)
+			log.Println(err)
+		}
+		return
+	}
+
+	// type cast our custom stack instance
+	// to access a few methods ...
+	stk := stackage.Stack(r)
+
+	// craft the landing page's contents
+	// to guide the user from there ...
+	directory := mainDirectory{
+		ID:       stk.ID(),
+		Kind:     stk.Kind(),
+		Category: stk.Category(),
+		Capacity: stk.Cap(),
+		Length:   stk.Len(),
+		ReadOnly: stk.IsReadOnly(),
+                Nesting:  stk.IsNesting(),
+	}
+
+	if directory.Length > 0 {
+		// don't alloc unless we have a reason
+		// to do so ...
+		directory.Slices = make([]int, 0)
+
+		// iterate slices, and obtain information
+		// from each to store within the directory.
+		for i := 0; i < stk.Len(); i++{
+			if _, ok := stk.Index(i); ok {
+				directory.Slices = append(directory.Slices, i)
+			}
+		}
+	}
+
+	// marshal directory type instance into JSON bytes.
+	j, err := json.MarshalIndent(directory,"", "\t")
+	if err != nil {
+		http.Error(resp, "Internal server error", 500)	// client-facing err - no sensitive details
+		log.Println(err)				// admin (console) err
+		return
+	}
+
+	// write successfully marshaled JSON bytes
+	// to the http.ResponseWriter, thus sending
+	// them to the client.
+	fmt.Fprintf(resp, string(j))
+	return
+}
+
+/*
+deleteOrPost is a compartmentalized method executed by slicesHandler. It
+is separated here just to keep any single method from being too large.
+
+This method handles generalized delete or post operations relating to
+data within the receiver.
+*/
+func (r MyStack) deleteOrPost(resp http.ResponseWriter, req *http.Request) (err error) {
+	var info updateInfo
+	if info, err = marshalUpdateInfo(req); err != nil {
+	        http.Error(resp, "Invalid POST bytes", http.StatusBadRequest) // tell the USER
+	        return
+	}
+        action := strings.ToLower(info.Action)
+
+	metherr := fmt.Errorf("Inappropriate resource (%s) for method %s, or resource not implemented", action, req.Method)
+
+        if req.Method == http.MethodDelete {
+		// method is HTTP DELETE
+
+		switch action {
+		case `remove`,`pop`,`reset`:
+			// reset requires a body parameter
+			// within the updateInfo instance
+			// for 'confirm', which is a bool.
+			// This is required to trash the
+			// entire stack. reset returns no
+			// data, and is a 204 (no content).
+			//
+			// remove returns a 204 (no content)
+			// with no body. remove requires a
+			// body parameter within updateInfo
+			// for 'idx', which is an integer
+			// and targets a specific slice for
+			// deletion.
+			//
+			// pop returns a 200 with the popped
+			// element expressed as JSON. pop
+			// requires no request body.
+                        err = r.popResetOrRemoveRequest(resp, info)
+		default:
+			err = metherr				// admin-facing (console) error
+                        http.Error(resp, err.Error(), 400)	// client-facing error (same error is fine here)
+		}
+
+        } else if req.Method == http.MethodPost {
+		// method is HTTP POST
+		//
+                // Now we can choose the appropriate modifier
+                // function to invoke for the request. Many of
+                // these actions are direct links to similarly
+                // named stackage.Stack methods.
+                switch action {
+                case `insert`:
+                        err = r.insertRequest(resp,info)
+                case `replace`:
+                        err = r.replaceRequest(resp,info)
+                case `push`:
+                        err = r.pushRequest(resp,info)
+
+                default:
+			err = metherr				// admin-facing (console) error
+                        http.Error(resp, err.Error(), 400)	// client-facing error (same error is fine here)
+                }
+        }
+
+	return
+}
+
+/*
+sliceHandler shall handle requests pertaining to the calling of a specific slice
+index, either direct (e.g.: /0) or via traversal path (e.g.: /0/1/2/1/1/0/...).
+*/
+func (r MyStack) sliceHandler(resp http.ResponseWriter, req *http.Request) {
+	resp.Header().Set("Content-Type", "application/json")
+
+	// Make sure the client isn't requesting some
+	// inappropriate HTTP method. Only support the
+	// ones listed here, and bail on anything else.
+	if !methodAllowed(req.Method, []string{
+		http.MethodPost,
+		http.MethodGet,
+		http.MethodDelete,
+	}) {
+		http.Error(resp, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	path := make([]int,0)
+	raw := strings.TrimSuffix(req.URL.Path,`/`)
+	indices := strings.Split(raw, `/`)
+	for i := 0 ; i < len(indices); i++ {
+		idx, err := strconv.Atoi(indices[i])
+		if err != nil {
+			http.Error(resp, "Unavailable", 503)
+			return
+		}
+		path = append(path,idx)
+	}
+
+	var sl any
+	var ok bool
+	var idx int
+
+	// perform a path length switch,
+	// handling the result in one (1)
+	// of three (3) different ways.
+	switch len(path) {
+	case 0:
+		// no result: get lost
+		http.Error(resp, "Not Found", 400)
+		return
+	case 1:
+		// one (1) path element indicates we
+		// can just call the Index method and
+		// be done with it.
+		if sl, ok = stackage.Stack(r).Index(path[0]); !ok || sl == nil {
+			http.Error(resp, "Not Found", 400)
+			return
+		}
+
+		if req.Method != http.MethodGet {
+			if err := r.deleteOrPost(resp, req); err != nil {
+				http.Error(resp, "Internal Server Error", 500)
+			}
+			return
+			// GO NO FURTHER IF NOT 'GET' METHOD
+		}
+		idx = path[0]
+	default:
+		// >1 path elements indicates Traversal needed ...
+		if sl, ok = stackage.Stack(r).Traverse(path...); !ok || sl == nil {
+			http.Error(resp, "Not Found", 400)
+			return
+		}
+
+		if req.Method != http.MethodGet {
+
+			// Make sure the slice we received back is
+			// something we can traverse.
+                        var stack MyStack
+                        switch tv := sl.(type) {
+                        case stackage.Stack:
+                                stack = MyStack(tv)
+                        case MyStack:
+                                stack = tv
+                        default:
+                                http.Error(resp, "Not traversable, cannot remove from target", 400)
+                                return
+                        }
+
+			// execute deleteOrPost method using the newly asserted
+			// MyStack instance (stack), and NOT the receiver (r),
+			// else we'd trash the wrong data!
+			if err := stack.deleteOrPost(resp, req); err != nil {
+				http.Error(resp, "Internal Server Error", 500)
+			}
+			return
+			// GO NO FURTHER IF NOT 'GET' METHOD
+		}
+
+		idx = path[len(path)-1]
+	}
+
+	// marshal sliceInfo instance into JSON bytes.
+        j, err := json.MarshalIndent(sliceInfo(sl,idx), "", "\t")
+        if err != nil {
+                http.Error(resp, "Internal server error", 500)	// user-facing error
+		fmt.Println(err)				// admin-facing (console) err
+                return
+        }
+
+	// write successfully marshaled JSON bytes
+	// to the http.ResponseWriter, thus sending
+	// them to the client.
+	fmt.Fprintf(resp, string(j))
+	return
+}
+
+/*
+v1Handler returns the root /api/<default_version> resource, which in this
+this case is a JSON payload of usage information and structural schemata.
+*/
+func v1Handler(resp http.ResponseWriter, req *http.Request) {
+	// Only GET allowed for this resource.
+	if req.Method != http.MethodGet {
+                http.Error(resp, "Method not allowed", 405)
+		return
+	}
+
+	// If URL does not begin with /api, get bent.
+	if !strings.HasPrefix(req.URL.Path, "/api") {
+		// SUGGESTIONS/IDEAS/ALTERNATIVES:
+		// - more helpful info written to resp?
+		// - redirect to help page?
+		http.NotFound(resp, req)
+		return
+	}
+
+	// becomes: /api/v1
+	apiRoot := APIDefault
+
+	help := struct{
+		APIRoot string `json:"api_root"`
+		Methods []string `json:"methods_available"`
+		Resources map[string]any `json:"resources"`
+	}{
+		APIRoot: apiRoot,
+		Methods: []string{http.MethodGet},
+		Resources: map[string]any{
+			"slice": struct{
+				Path string `json:"path"`
+				Description string `json:"description"`
+			}{
+				Path: apiRoot + "/slice",
+				Description: "Main index of all slice indices present",
+			},
+		},
+	}
+
+        j, err := json.MarshalIndent(help, "", "\t")
+        if err != nil {
+                http.Error(resp, "Internal server error", 500)
+                return
+        }
+
+	fmt.Fprintf(resp, string(j))
+}
+
+/*
+v2Handler is a bogus parallel API branch that is present merely for users
+to customize into something usable, or to act as a dead-end alternative to
+the v1Handler, thereby allowing the testing of an APIDefault fallback.
+
+In its current state, this will return a 'Not Implemented' (501) when used
+properly.
+*/
+func v2Handler(resp http.ResponseWriter, req *http.Request) {
+        // Only GET allowed for this resource.
+        if req.Method != http.MethodGet {
+                http.Error(resp, "Method not allowed", 405)
+                return
+        }
+
+        // If URL does not begin with /api, get bent.
+        if !strings.HasPrefix(req.URL.Path, "/api") {
+                // SUGGESTIONS/IDEAS/ALTERNATIVES:
+                // - more helpful info written to resp?
+                // - redirect to help page?
+                http.NotFound(resp, req)
+                return
+        }
+
+        http.Error(resp, "Resource not implemented", 501)
+	return
+}
+
+/*
+rootHandler is the handlerfunc instance for any request which
+lands upon the root (/) context.
+*/
+func rootHandler(resp http.ResponseWriter, req *http.Request) {
+        resp.Header().Set("Content-Type", "text/html")
+
+        if req.URL.Path != "/" {
+                http.NotFound(resp, req)
+                return
+        }
+
+        // Here we write basic HTML to the responsewriter,
+        // to (cleanly) welcome clients who are visiting
+        // the resource with a GUI browser as opposed to
+        // curl/wget...
+        fmt.Fprintf(resp,`
+                <html>
+                <head>
+                        <h2 style="font-family:monospace";>Welcome to the Netstack API Demo</h2>
+                </head>
+                <body>
+                        <p style="font-family:monospace";>coming soon! maybe! See the <a href="/api">API</a> section for access to stack data</p>
+                </body>
+                </html>
+        `)
+}
+
+/*
+valueHandler will take appropriate steps to ensure a value
+is string represented properly and is JSON friendly ...
+*/
+func stackValueHandler(x any) (slices []slice) {
+	switch tv := x.(type) {
+	case stackage.Stack:
+		slices = make([]slice, tv.Len())
+		for i := 0; i < tv.Len(); i++ {
+			sl, _ := tv.Index(i)
+			switch uv := sl.(type) {
+			case stackage.Stack:
+				// cast stackage.Stack to main.MyStack
+				slices[i] = sliceInfo(MyStack(uv),i)
+			default:
+				slices[i] = sliceInfo(uv,i)
+			}
+		}
+
+	case MyStack:
+		return stackValueHandler(stackage.Stack(tv))
+	}
+
+	return
+}
+
+/*
+sliceInfo attempts to marshal x -- as an explicit value 
+and expressed as "meta data" -- into an instance of slice.
+*/
+func sliceInfo(x any, idx int) (s slice) {
+        s.Index = idx
+
+        switch tv := x.(type) {
+	case MyStack:
+		// cast + self-execute for simplicity
+		s = sliceInfo(stackage.Stack(tv), idx)
+		s.Type = fmt.Sprintf("%T", tv)
+
+        case stackage.Stack:
+                s.Value = stackValueHandler(tv)
+		s.Type = fmt.Sprintf("%T", tv)
+		s.Kind = tv.Kind()
+		s.Length = tv.Len()
+		s.Capacity = tv.Cap()
+                s.Nesting =  tv.IsNesting()
+                s.ReadOnly = tv.IsReadOnly()
+		s.FIFO = tv.IsFIFO()
+		s.ID = tv.ID()
+		s.Category = tv.Category()
+
+	case rune:
+		s.Type = fmt.Sprintf("%T", tv)
+		s.Value = fmt.Sprintf("%c", tv)
+
+	case int, int8, int16, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		s.Value = tv
+		s.Type = fmt.Sprintf("%T", tv)
+
+	case string:
+		s.Type = fmt.Sprintf("%T", tv)
+		s.Length = len(tv)
+		s.Value = tv
+
+	case []any:
+		s.Type = fmt.Sprintf("%T", tv)
+		s.Length = len(tv)
+		s.Capacity = cap(tv)
+		s.Value = tv
+
+        default:
+		s.Type = fmt.Sprintf("%T", tv)
+                s.Value = fmt.Sprintf("%v", tv)
+
+        }
+
+	return
+}
+
+/*
+methodAllowed scans the available methods to determine whether meth
+is among them. Case is not significant in the matching process.
+*/
+func methodAllowed(meth string, methods []string) bool {
+	for i := 0; i < len(methods); i++ {
+		if strings.EqualFold(meth,methods[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+/*
+marshalUpdateInfo will attempt to marshal the request body
+bytes into an instance of updateInfo, which can be used by
+eligible handler funcs to effect changes upon the stack
+and/or its contents.
+*/
+func marshalUpdateInfo(req *http.Request) (info updateInfo, err error) {
+	// read resp. body (don't need
+	// to close manually though).
+	var body []byte
+	if body, err = io.ReadAll(req.Body); err != nil {
+	        return
+	}
+
+	// define unmarshal destination
+	// and unmarshal content into it.
+	// Make a note of the method as
+	// well ...
+	info.Method = http.MethodPost
+	err = json.Unmarshal(body, &info)
+	return
+}
+
+/*
+insertRequest wraps stackage.Stack's Insert method.
+
+See pkg.go.dev/github.com/JesseCoretta/go-stackage#Stack.Insert
+for signature and other details.
+*/
+func (r MyStack) insertRequest(resp http.ResponseWriter, info updateInfo) (err error) {
+	raw, found := info.Parameters[`left`]
+	if !found {
+		err = fmt.Errorf("Missing 'left' key parameter")
+		return
+	}
+
+	assert, ok := raw.(float64)
+	if !ok {
+		err = fmt.Errorf("Bad request; 'left' body parameter NaN")
+		http.Error(resp, err.Error(), 400)
+		return
+	}
+	left := int(assert)
+
+	value, found := info.Parameters[`value`]
+	if !found {
+		err = fmt.Errorf("Missing 'value' key parameter")
+		http.Error(resp, err.Error(), 400)
+		return
+	}
+
+	switch tv := value.(type) {
+	case []any:
+                stackage.Stack(r).Insert(revEngStack(tv),left)
+	default:
+                stackage.Stack(r).Insert(tv,left)
+	}
+
+	return
+}
+
+/*
+replaceRequest wraps stackage.Stack's Replace method.
+
+See pkg.go.dev/github.com/JesseCoretta/go-stackage#Stack.Replace
+for signature and other details.
+*/
+func (r MyStack) replaceRequest(resp http.ResponseWriter, info updateInfo) (err error) {
+        idx, found := info.Parameters[`idx`]
+        if !found {
+                err = fmt.Errorf("Missing 'idx' key parameter")
+                return
+        }
+
+	assert, ok := idx.(float64)
+	if !ok {
+		http.Error(resp, "Bad request; 'idx' body parameter NaN", 400)
+		err = fmt.Errorf("'idx' parameter must be an integer")
+		return
+	}
+        index := int(assert)
+
+        value, found := info.Parameters[`value`]
+        if !found {
+                err = fmt.Errorf("Missing 'value' key parameter")
+                return
+        }
+
+        switch tv := value.(type) {
+        case []any:
+                stackage.Stack(r).Replace(revEngStack(tv),index)
+
+	default:
+                stackage.Stack(r).Replace(tv,index)
+        }
+
+        return
+}
+
+/*
+pushRequest wraps stackage.Stack's Push method.
+
+See pkg.go.dev/github.com/JesseCoretta/go-stackage#Stack.Push
+for signature and other details.
+*/
+func (r MyStack) pushRequest(resp http.ResponseWriter, info updateInfo) (err error) {
+        value, found := info.Parameters[`value`]
+        if !found {
+                err = fmt.Errorf("Missing 'value' key parameter")
+                return
+        }
+
+        switch tv := value.(type) {
+        case []any:
+		if len(tv) > 0 {
+			stackage.Stack(r).Push(revEngStack(tv))
+			resp.WriteHeader(http.StatusNoContent)	// 204
+			return
+		}
+
+        default:
+		if tv != nil {
+			stackage.Stack(r).Push(tv)
+			resp.WriteHeader(http.StatusNoContent)	// 204
+			return
+		}
+        }
+
+	http.Error(resp, "Bad request; unknown push type, or empty payload", 400)
+
+        return
+}
+
+/*
+revEngStack attempts to reverse-engineer a stack based on the state and
+composition of an instance of []any (slices of interface) that was sent
+by the user via a POST operation containing a JSON payload.
+
+Patterns are as follows.
+
+  - Index 0 with a string value of `or` shall execute stackage.Or
+  - Index 0 with a string value of `and` shall execute stackage.And
+  - Index 0 with a string value of `not` shall execute stackage.Not
+  - Index 0 with a string value of `list` shall execute stackage.List
+
+If no desired pattern is discerned, a fallback stack type initialized by
+stackage.Basic shall be used.
+
+Once a stack instance is initialized, the contents of x (slices #1 and up)
+are pushed into it using the Push method.
+*/
+func revEngStack(x []any) (stack any) {
+        word, _ := x[0].(string) // fallback to basic if assertion fails
+
+        switch strings.ToLower(word) {
+        case `or`, `and`, `not`, `list`:
+                stack = stackFromBooleanOperator(word)
+        default:
+                stack = stackFromBooleanOperator(`basic`)
+        }
+
+	for i := 1; i < len(x); i++ {
+		stackage.Stack(stack.(MyStack)).Push(x[i])
+	}
+
+	return
+}
+
+/*
+popResetOrRemoveRequest handles any stackage.Reset/Pop/Remove request
+made by the user via JSON instruction payload.
+*/
+func (r MyStack) popResetOrRemoveRequest(resp http.ResponseWriter, info updateInfo) (err error) {
+	switch strings.ToLower(info.Action) {
+	case `reset`:
+                target, found := info.Parameters[`confirm`]
+                if !found {
+                        http.Error(resp, "Bad request; missing 'confirm' body parameter", 400)
+                        err = fmt.Errorf("Missing 'confirm' key parameter; this is required for 'reset'")
+                        break
+                }
+		assert, ok := target.(bool)
+		if !ok {
+			http.Error(resp, "Bad request; 'confirm' body parameter not a boolean", 400)
+			err = fmt.Errorf("'confirm' body parameter must be a bool")
+			break
+		}
+
+		if assert {
+			stackage.Stack(r).Reset()
+		}
+		resp.WriteHeader(http.StatusNoContent)	// 204
+
+	case `pop`:
+		var idx int = stackage.Stack(r).Len()-1
+		if stackage.Stack(r).IsFIFO() {
+			idx = 0
+		}
+
+		popped, ok := stackage.Stack(r).Pop()
+		if !ok {
+			err = fmt.Errorf("Failed to pop element from %T", r)
+			break
+		}
+
+		var j []byte
+		if j, err = json.MarshalIndent(sliceInfo(popped,idx), "", "\t"); err != nil {
+			http.Error(resp, "Internal server error", 500)
+			break
+		}
+
+		fmt.Fprintln(resp, string(j))
+
+	case `remove`:
+	        target, found := info.Parameters[`idx`]
+	        if !found {
+			http.Error(resp, "Bad request; missing 'idx' body parameter", 400)
+	                err = fmt.Errorf("Missing 'idx' key parameter; this is required for 'remove'")
+	                break
+	        }
+
+		assert, ok := target.(float64)
+		if !ok {
+			http.Error(resp, "Bad request; 'idx' body parameter NaN", 400)
+			err = fmt.Errorf("'idx' parameter must be an integer")
+			break
+		}
+
+		log.Printf("---> %s", stackage.Stack(r).ID())
+		stackage.Stack(r).Remove(int(assert))
+		resp.WriteHeader(http.StatusNoContent)	// 204
+	}
+
+        return
+}
+
+/*
+stackFromBooleanOperator returns a ready-to-use instance of
+stackage.Stack -- initialized by the appropriate function --
+cast as an instance of MyStack.
+
+The fallback stack type used for invalid requests is Basic.
+*/
+func stackFromBooleanOperator(word string) (stack MyStack) {
+	switch strings.ToLower(word) {
+	case `or`:
+	        stack = MyStack(stackage.Or())
+	case `and`:
+	        stack = MyStack(stackage.And())
+	case `not`:
+	        stack = MyStack(stackage.Not())
+	case `list`:
+	        stack = MyStack(stackage.List())
+	default:
+	        stack = MyStack(stackage.Basic())
+	}
+
+	return
+}
+

--- a/_examples/main_netstack_readwrite.go
+++ b/_examples/main_netstack_readwrite.go
@@ -53,9 +53,9 @@ However, we are able to ACCESS those methods by simply
 type-casting MyStack->Stack.  For example, to access the
 Len method in a MyStack instance:
 
-  var mystack MyStack // assume this has been populated with something
-  fmt.Printf("Length of %T: %d", mystack, stackage.Stack(mystack).Len())
-  // Output: Length of main.MyStack: 2
+	var mystack MyStack // assume this has been populated with something
+	fmt.Printf("Length of %T: %d", mystack, stackage.Stack(mystack).Len())
+	// Output: Length of main.MyStack: 2
 
 Note that when we cast mystack within Stack, we're accessing
 the underlying embedded pointer instance. If we need to make
@@ -75,7 +75,7 @@ the only option. One could conceivably put the
 contents in their own Auxiliary key/value pair
 and do it that way.
 */
-type MyMuX struct{
+type MyMuX struct {
 	*http.Server
 	*http.ServeMux
 }
@@ -87,30 +87,30 @@ instance 'remove', 'insert', and others.
 
 It would be delivered via a command such as
 
-  curl -X POST <scheme://addr> -d '<this_type_marshaled_as_json_bytes>'
+	curl -X POST <scheme://addr> -d '<this_type_marshaled_as_json_bytes>'
 */
 type updateInfo struct {
-       Action  string	      `json:"action"`		 // the stackage method name, such as 'insert' (case not important)
-       Method  string	      `json:"-"`		 // typically POST or DELETE, not set by user explicitly, not visible in JSON
-       Parameters map[string]any `json:"parameters,omitempty"` // input params required by various stackage.Stack methods
+	Action     string         `json:"action"`               // the stackage method name, such as 'insert' (case not important)
+	Method     string         `json:"-"`                    // typically POST or DELETE, not set by user explicitly, not visible in JSON
+	Parameters map[string]any `json:"parameters,omitempty"` // input params required by various stackage.Stack methods
 }
 
 /*
 slice is the abstraction of any particular
 slice value within a stack.
 */
-type slice struct{
-        Type     string	`json:"type"`
+type slice struct {
+	Type     string `json:"type"`
 	ID       string `json:"identifier,omitempty"`
 	Kind     string `json:"kind,omitempty"`
 	Category string `json:"category,omitempty"`
 	Capacity int    `json:"capacity,omitempty"`
 	Length   int    `json:"length,omitempty"`
-        Index    int	`json:"index"`
-	Nesting  bool	`json:"nesting,omitempty"`
-	ReadOnly bool	`json:"readonly,omitempty"`
+	Index    int    `json:"index"`
+	Nesting  bool   `json:"nesting,omitempty"`
+	ReadOnly bool   `json:"readonly,omitempty"`
 	FIFO     bool   `json:"fifo,omitempty"`
-        Value    any	`json:"value"`
+	Value    any    `json:"value"`
 }
 
 /*
@@ -121,11 +121,11 @@ hypothetical app, in essence.
 */
 func main() {
 	log.SetFlags(0)
-        stackage.SetDefaultStackLogLevel(`ALL`)
-        stackage.SetDefaultStackLogger(`stdout`)
+	stackage.SetDefaultStackLogLevel(`ALL`)
+	stackage.SetDefaultStackLogger(`stdout`)
 
-        stackage.SetDefaultConditionLogLevel(`ALL`)
-        stackage.SetDefaultConditionLogger(`stdout`)
+	stackage.SetDefaultConditionLogLevel(`ALL`)
+	stackage.SetDefaultConditionLogger(`stdout`)
 
 	// create signal channel to gracefully
 	// receive CTRL+C (^C) sequences. Note
@@ -153,7 +153,7 @@ func main() {
 	// ... until you receive a signal, at which
 	// point, shutdown gracefully (Shutdown) by
 	// feeding it a background Context instance.
-	ctx, cancel := context.WithTimeout(context.Background(), 60 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	if err := stack.Shutdown(ctx); err != nil {
 		log.Fatal(err)
@@ -195,13 +195,13 @@ func MakeStack() MyStack {
 		)),
 		MyStack(stackage.And().SetID(`_random`).Push(
 			MyStack(stackage.Or().SetID(`_random`).Push(
-				stackage.Cond(`name`,stackage.Eq,`Mike`),
-				stackage.Cond(`name`,stackage.Eq,`Courtney`),
+				stackage.Cond(`name`, stackage.Eq, `Mike`),
+				stackage.Cond(`name`, stackage.Eq, `Courtney`),
 			)),
 			MyStack(stackage.Not().SetID(`negations`).Push(
 				MyStack(stackage.Or(4).SetID(`or_negation`).Push(
-					stackage.Cond(`terminated`,stackage.Eq,true),
-					stackage.Cond(`disgruntled`,stackage.Eq,true),
+					stackage.Cond(`terminated`, stackage.Eq, true),
+					stackage.Cond(`disgruntled`, stackage.Eq, true),
 				)),
 			)),
 		)),
@@ -240,7 +240,7 @@ of this method, which is the main() function in this demo.
 func (r MyStack) Shutdown(ctx context.Context) (err error) {
 	log.Printf("\nReceived termination signal")
 
-        srv := r.Server()
+	srv := r.Server()
 	if err = srv.Shutdown(ctx); err != nil {
 		return
 	}
@@ -262,16 +262,16 @@ receiver instance. Only the "top-level" or "outermost"
 stack instance requires this setup procedure.
 */
 func (r MyStack) SetListener(addr ...string) MyStack {
-        var address string = ":8080"
-        if len(addr) > 0 {
-                address = addr[0]
-        }
+	var address string = ":8080"
+	if len(addr) > 0 {
+		address = addr[0]
+	}
 
 	// Assembly of our multiplexer
 	// and http server
 	mux := http.NewServeMux()
 	srv := &http.Server{Addr: address, Handler: mux}
-	ls := MyMuX{srv,mux}
+	ls := MyMuX{srv, mux}
 
 	// Pass the receiver (MyStack) into the Configure
 	// method. This creates routes and handlers used
@@ -283,10 +283,10 @@ func (r MyStack) SetListener(addr ...string) MyStack {
 	// instance (Auxiliary) for administrative use. In
 	// particular, it is needed to store the listener
 	// system assembled above ...
-	stackage.Stack(r).		// cast MyStack->Stack
-		SetAuxiliary().		// init map (only needed once)
-		Auxiliary().		// call map
-		Set(`listener`, ls)	// set listener instance (ls) as map value identified by key `listener`
+	stackage.Stack(r). // cast MyStack->Stack
+				SetAuxiliary().     // init map (only needed once)
+				Auxiliary().        // call map
+				Set(`listener`, ls) // set listener instance (ls) as map value identified by key `listener`
 
 	return r
 }
@@ -312,11 +312,11 @@ of this method, the process is used to return the instance of the
 *http.Server, which was assembled within the SetListener method.
 */
 func (r MyStack) Server() *http.Server {
-        val, found := stackage.Stack(r).Auxiliary().Get(`listener`)
-        if !found {
-                return nil
-        }
-        return val.(MyMuX).Server
+	val, found := stackage.Stack(r).Auxiliary().Get(`listener`)
+	if !found {
+		return nil
+	}
+	return val.(MyMuX).Server
 }
 
 /*
@@ -328,21 +328,21 @@ their own paths, etc., as needed to suit their data structure.
 func (r *MyMuX) Configure(stack MyStack) MyMuX {
 
 	// Begin setting up our fundamental handlers
-        r.ServeMux.HandleFunc("/", rootHandler)					// absolute root of listener "/"
-        r.ServeMux.Handle(APIRoot,    http.RedirectHandler(APIDefault,302))	// "/api"
-        r.ServeMux.Handle(APIDefault, http.HandlerFunc(v1Handler))		// "/api/v1"
+	r.ServeMux.HandleFunc("/", rootHandler)                           // absolute root of listener "/"
+	r.ServeMux.Handle(APIRoot, http.RedirectHandler(APIDefault, 302)) // "/api"
+	r.ServeMux.Handle(APIDefault, http.HandlerFunc(v1Handler))        // "/api/v1"
 
 	// This is an unimplemented handler, always
 	// returns HTTP 501: Not Implemented.
 	apiV2 := APIRoot + `/v2`
-        r.ServeMux.Handle(apiV2, http.HandlerFunc(v2Handler))			// "/api/v2" (dead-end)
+	r.ServeMux.Handle(apiV2, http.HandlerFunc(v2Handler)) // "/api/v2" (dead-end)
 
 	// "/slice" by itself brings the user to
 	// the main landing page for the slice,
 	// which contains a list of available
 	// slice indices.
-        slicesPath := APIDefault + "/slice"
-        r.ServeMux.HandleFunc(slicesPath, stack.slicesHandler)
+	slicesPath := APIDefault + "/slice"
+	r.ServeMux.HandleFunc(slicesPath, stack.slicesHandler)
 
 	// "/slice/<N>" (e.g.: "/slice/1") will
 	// bring the user to the page for the
@@ -357,8 +357,8 @@ func (r *MyMuX) Configure(stack MyStack) MyMuX {
 	// function can more easily split the
 	// path into discrete indices as shown
 	// in the above example.
-        r.ServeMux.Handle(slicesPath + `/`, http.StripPrefix(
-		slicesPath + `/`,
+	r.ServeMux.Handle(slicesPath+`/`, http.StripPrefix(
+		slicesPath+`/`,
 		http.HandlerFunc(stack.sliceHandler),
 	))
 
@@ -407,7 +407,7 @@ func (r MyStack) slicesHandler(resp http.ResponseWriter, req *http.Request) {
 		Capacity int    `json:"cap,omitempty"`
 		ReadOnly bool   `json:"readonly,omitempty"`
 		Nesting  bool   `json:"nesting,omitempty"`
-		Slices []int    `json:"slices"`
+		Slices   []int  `json:"slices"`
 	}
 
 	// If method is POST or DELETE, just run the contents
@@ -433,7 +433,7 @@ func (r MyStack) slicesHandler(resp http.ResponseWriter, req *http.Request) {
 		Capacity: stk.Cap(),
 		Length:   stk.Len(),
 		ReadOnly: stk.IsReadOnly(),
-                Nesting:  stk.IsNesting(),
+		Nesting:  stk.IsNesting(),
 	}
 
 	if directory.Length > 0 {
@@ -443,7 +443,7 @@ func (r MyStack) slicesHandler(resp http.ResponseWriter, req *http.Request) {
 
 		// iterate slices, and obtain information
 		// from each to store within the directory.
-		for i := 0; i < stk.Len(); i++{
+		for i := 0; i < stk.Len(); i++ {
 			if _, ok := stk.Index(i); ok {
 				directory.Slices = append(directory.Slices, i)
 			}
@@ -451,10 +451,10 @@ func (r MyStack) slicesHandler(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	// marshal directory type instance into JSON bytes.
-	j, err := json.MarshalIndent(directory,"", "\t")
+	j, err := json.MarshalIndent(directory, "", "\t")
 	if err != nil {
-		http.Error(resp, "Internal server error", 500)	// client-facing err - no sensitive details
-		log.Println(err)				// admin (console) err
+		http.Error(resp, "Internal server error", 500) // client-facing err - no sensitive details
+		log.Println(err)                               // admin (console) err
 		return
 	}
 
@@ -475,18 +475,18 @@ data within the receiver.
 func (r MyStack) deleteOrPost(resp http.ResponseWriter, req *http.Request) (err error) {
 	var info updateInfo
 	if info, err = marshalUpdateInfo(req); err != nil {
-	        http.Error(resp, "Invalid POST bytes", http.StatusBadRequest) // tell the USER
-	        return
+		http.Error(resp, "Invalid POST bytes", http.StatusBadRequest) // tell the USER
+		return
 	}
-        action := strings.ToLower(info.Action)
+	action := strings.ToLower(info.Action)
 
 	metherr := fmt.Errorf("Inappropriate resource (%s) for method %s, or resource not implemented", action, req.Method)
 
-        if req.Method == http.MethodDelete {
+	if req.Method == http.MethodDelete {
 		// method is HTTP DELETE
 
 		switch action {
-		case `remove`,`pop`,`reset`:
+		case `remove`, `pop`, `reset`:
 			// reset requires a body parameter
 			// within the updateInfo instance
 			// for 'confirm', which is a bool.
@@ -504,32 +504,32 @@ func (r MyStack) deleteOrPost(resp http.ResponseWriter, req *http.Request) (err 
 			// pop returns a 200 with the popped
 			// element expressed as JSON. pop
 			// requires no request body.
-                        err = r.popResetOrRemoveRequest(resp, info)
+			err = r.popResetOrRemoveRequest(resp, info)
 		default:
-			err = metherr				// admin-facing (console) error
-                        http.Error(resp, err.Error(), 400)	// client-facing error (same error is fine here)
+			err = metherr                      // admin-facing (console) error
+			http.Error(resp, err.Error(), 400) // client-facing error (same error is fine here)
 		}
 
-        } else if req.Method == http.MethodPost {
+	} else if req.Method == http.MethodPost {
 		// method is HTTP POST
 		//
-                // Now we can choose the appropriate modifier
-                // function to invoke for the request. Many of
-                // these actions are direct links to similarly
-                // named stackage.Stack methods.
-                switch action {
-                case `insert`:
-                        err = r.insertRequest(resp,info)
-                case `replace`:
-                        err = r.replaceRequest(resp,info)
-                case `push`:
-                        err = r.pushRequest(resp,info)
+		// Now we can choose the appropriate modifier
+		// function to invoke for the request. Many of
+		// these actions are direct links to similarly
+		// named stackage.Stack methods.
+		switch action {
+		case `insert`:
+			err = r.insertRequest(resp, info)
+		case `replace`:
+			err = r.replaceRequest(resp, info)
+		case `push`:
+			err = r.pushRequest(resp, info)
 
-                default:
-			err = metherr				// admin-facing (console) error
-                        http.Error(resp, err.Error(), 400)	// client-facing error (same error is fine here)
-                }
-        }
+		default:
+			err = metherr                      // admin-facing (console) error
+			http.Error(resp, err.Error(), 400) // client-facing error (same error is fine here)
+		}
+	}
 
 	return
 }
@@ -553,16 +553,16 @@ func (r MyStack) sliceHandler(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	path := make([]int,0)
-	raw := strings.TrimSuffix(req.URL.Path,`/`)
+	path := make([]int, 0)
+	raw := strings.TrimSuffix(req.URL.Path, `/`)
 	indices := strings.Split(raw, `/`)
-	for i := 0 ; i < len(indices); i++ {
+	for i := 0; i < len(indices); i++ {
 		idx, err := strconv.Atoi(indices[i])
 		if err != nil {
 			http.Error(resp, "Unavailable", 503)
 			return
 		}
-		path = append(path,idx)
+		path = append(path, idx)
 	}
 
 	var sl any
@@ -605,16 +605,16 @@ func (r MyStack) sliceHandler(resp http.ResponseWriter, req *http.Request) {
 
 			// Make sure the slice we received back is
 			// something we can traverse.
-                        var stack MyStack
-                        switch tv := sl.(type) {
-                        case stackage.Stack:
-                                stack = MyStack(tv)
-                        case MyStack:
-                                stack = tv
-                        default:
-                                http.Error(resp, "Not traversable, cannot remove from target", 400)
-                                return
-                        }
+			var stack MyStack
+			switch tv := sl.(type) {
+			case stackage.Stack:
+				stack = MyStack(tv)
+			case MyStack:
+				stack = tv
+			default:
+				http.Error(resp, "Not traversable, cannot remove from target", 400)
+				return
+			}
 
 			// execute deleteOrPost method using the newly asserted
 			// MyStack instance (stack), and NOT the receiver (r),
@@ -630,12 +630,12 @@ func (r MyStack) sliceHandler(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	// marshal sliceInfo instance into JSON bytes.
-        j, err := json.MarshalIndent(sliceInfo(sl,idx), "", "\t")
-        if err != nil {
-                http.Error(resp, "Internal server error", 500)	// user-facing error
-		fmt.Println(err)				// admin-facing (console) err
-                return
-        }
+	j, err := json.MarshalIndent(sliceInfo(sl, idx), "", "\t")
+	if err != nil {
+		http.Error(resp, "Internal server error", 500) // user-facing error
+		fmt.Println(err)                               // admin-facing (console) err
+		return
+	}
 
 	// write successfully marshaled JSON bytes
 	// to the http.ResponseWriter, thus sending
@@ -651,7 +651,7 @@ this case is a JSON payload of usage information and structural schemata.
 func v1Handler(resp http.ResponseWriter, req *http.Request) {
 	// Only GET allowed for this resource.
 	if req.Method != http.MethodGet {
-                http.Error(resp, "Method not allowed", 405)
+		http.Error(resp, "Method not allowed", 405)
 		return
 	}
 
@@ -667,29 +667,29 @@ func v1Handler(resp http.ResponseWriter, req *http.Request) {
 	// becomes: /api/v1
 	apiRoot := APIDefault
 
-	help := struct{
-		APIRoot string `json:"api_root"`
-		Methods []string `json:"methods_available"`
+	help := struct {
+		APIRoot   string         `json:"api_root"`
+		Methods   []string       `json:"methods_available"`
 		Resources map[string]any `json:"resources"`
 	}{
 		APIRoot: apiRoot,
 		Methods: []string{http.MethodGet},
 		Resources: map[string]any{
-			"slice": struct{
-				Path string `json:"path"`
+			"slice": struct {
+				Path        string `json:"path"`
 				Description string `json:"description"`
 			}{
-				Path: apiRoot + "/slice",
+				Path:        apiRoot + "/slice",
 				Description: "Main index of all slice indices present",
 			},
 		},
 	}
 
-        j, err := json.MarshalIndent(help, "", "\t")
-        if err != nil {
-                http.Error(resp, "Internal server error", 500)
-                return
-        }
+	j, err := json.MarshalIndent(help, "", "\t")
+	if err != nil {
+		http.Error(resp, "Internal server error", 500)
+		return
+	}
 
 	fmt.Fprintf(resp, string(j))
 }
@@ -703,22 +703,22 @@ In its current state, this will return a 'Not Implemented' (501) when used
 properly.
 */
 func v2Handler(resp http.ResponseWriter, req *http.Request) {
-        // Only GET allowed for this resource.
-        if req.Method != http.MethodGet {
-                http.Error(resp, "Method not allowed", 405)
-                return
-        }
+	// Only GET allowed for this resource.
+	if req.Method != http.MethodGet {
+		http.Error(resp, "Method not allowed", 405)
+		return
+	}
 
-        // If URL does not begin with /api, get bent.
-        if !strings.HasPrefix(req.URL.Path, "/api") {
-                // SUGGESTIONS/IDEAS/ALTERNATIVES:
-                // - more helpful info written to resp?
-                // - redirect to help page?
-                http.NotFound(resp, req)
-                return
-        }
+	// If URL does not begin with /api, get bent.
+	if !strings.HasPrefix(req.URL.Path, "/api") {
+		// SUGGESTIONS/IDEAS/ALTERNATIVES:
+		// - more helpful info written to resp?
+		// - redirect to help page?
+		http.NotFound(resp, req)
+		return
+	}
 
-        http.Error(resp, "Resource not implemented", 501)
+	http.Error(resp, "Resource not implemented", 501)
 	return
 }
 
@@ -727,18 +727,18 @@ rootHandler is the handlerfunc instance for any request which
 lands upon the root (/) context.
 */
 func rootHandler(resp http.ResponseWriter, req *http.Request) {
-        resp.Header().Set("Content-Type", "text/html")
+	resp.Header().Set("Content-Type", "text/html")
 
-        if req.URL.Path != "/" {
-                http.NotFound(resp, req)
-                return
-        }
+	if req.URL.Path != "/" {
+		http.NotFound(resp, req)
+		return
+	}
 
-        // Here we write basic HTML to the responsewriter,
-        // to (cleanly) welcome clients who are visiting
-        // the resource with a GUI browser as opposed to
-        // curl/wget...
-        fmt.Fprintf(resp,`
+	// Here we write basic HTML to the responsewriter,
+	// to (cleanly) welcome clients who are visiting
+	// the resource with a GUI browser as opposed to
+	// curl/wget...
+	fmt.Fprintf(resp, `
                 <html>
                 <head>
                         <h2 style="font-family:monospace";>Welcome to the Netstack API Demo</h2>
@@ -763,9 +763,9 @@ func stackValueHandler(x any) (slices []slice) {
 			switch uv := sl.(type) {
 			case stackage.Stack:
 				// cast stackage.Stack to main.MyStack
-				slices[i] = sliceInfo(MyStack(uv),i)
+				slices[i] = sliceInfo(MyStack(uv), i)
 			default:
-				slices[i] = sliceInfo(uv,i)
+				slices[i] = sliceInfo(uv, i)
 			}
 		}
 
@@ -777,26 +777,26 @@ func stackValueHandler(x any) (slices []slice) {
 }
 
 /*
-sliceInfo attempts to marshal x -- as an explicit value 
+sliceInfo attempts to marshal x -- as an explicit value
 and expressed as "meta data" -- into an instance of slice.
 */
 func sliceInfo(x any, idx int) (s slice) {
-        s.Index = idx
+	s.Index = idx
 
-        switch tv := x.(type) {
+	switch tv := x.(type) {
 	case MyStack:
 		// cast + self-execute for simplicity
 		s = sliceInfo(stackage.Stack(tv), idx)
 		s.Type = fmt.Sprintf("%T", tv)
 
-        case stackage.Stack:
-                s.Value = stackValueHandler(tv)
+	case stackage.Stack:
+		s.Value = stackValueHandler(tv)
 		s.Type = fmt.Sprintf("%T", tv)
 		s.Kind = tv.Kind()
 		s.Length = tv.Len()
 		s.Capacity = tv.Cap()
-                s.Nesting =  tv.IsNesting()
-                s.ReadOnly = tv.IsReadOnly()
+		s.Nesting = tv.IsNesting()
+		s.ReadOnly = tv.IsReadOnly()
 		s.FIFO = tv.IsFIFO()
 		s.ID = tv.ID()
 		s.Category = tv.Category()
@@ -822,11 +822,11 @@ func sliceInfo(x any, idx int) (s slice) {
 		s.Capacity = cap(tv)
 		s.Value = tv
 
-        default:
+	default:
 		s.Type = fmt.Sprintf("%T", tv)
-                s.Value = fmt.Sprintf("%v", tv)
+		s.Value = fmt.Sprintf("%v", tv)
 
-        }
+	}
 
 	return
 }
@@ -837,7 +837,7 @@ is among them. Case is not significant in the matching process.
 */
 func methodAllowed(meth string, methods []string) bool {
 	for i := 0; i < len(methods); i++ {
-		if strings.EqualFold(meth,methods[i]) {
+		if strings.EqualFold(meth, methods[i]) {
 			return true
 		}
 	}
@@ -855,7 +855,7 @@ func marshalUpdateInfo(req *http.Request) (info updateInfo, err error) {
 	// to close manually though).
 	var body []byte
 	if body, err = io.ReadAll(req.Body); err != nil {
-	        return
+		return
 	}
 
 	// define unmarshal destination
@@ -897,9 +897,9 @@ func (r MyStack) insertRequest(resp http.ResponseWriter, info updateInfo) (err e
 
 	switch tv := value.(type) {
 	case []any:
-                stackage.Stack(r).Insert(revEngStack(tv),left)
+		stackage.Stack(r).Insert(revEngStack(tv), left)
 	default:
-                stackage.Stack(r).Insert(tv,left)
+		stackage.Stack(r).Insert(tv, left)
 	}
 
 	return
@@ -912,11 +912,11 @@ See pkg.go.dev/github.com/JesseCoretta/go-stackage#Stack.Replace
 for signature and other details.
 */
 func (r MyStack) replaceRequest(resp http.ResponseWriter, info updateInfo) (err error) {
-        idx, found := info.Parameters[`idx`]
-        if !found {
-                err = fmt.Errorf("Missing 'idx' key parameter")
-                return
-        }
+	idx, found := info.Parameters[`idx`]
+	if !found {
+		err = fmt.Errorf("Missing 'idx' key parameter")
+		return
+	}
 
 	assert, ok := idx.(float64)
 	if !ok {
@@ -924,23 +924,23 @@ func (r MyStack) replaceRequest(resp http.ResponseWriter, info updateInfo) (err 
 		err = fmt.Errorf("'idx' parameter must be an integer")
 		return
 	}
-        index := int(assert)
+	index := int(assert)
 
-        value, found := info.Parameters[`value`]
-        if !found {
-                err = fmt.Errorf("Missing 'value' key parameter")
-                return
-        }
+	value, found := info.Parameters[`value`]
+	if !found {
+		err = fmt.Errorf("Missing 'value' key parameter")
+		return
+	}
 
-        switch tv := value.(type) {
-        case []any:
-                stackage.Stack(r).Replace(revEngStack(tv),index)
+	switch tv := value.(type) {
+	case []any:
+		stackage.Stack(r).Replace(revEngStack(tv), index)
 
 	default:
-                stackage.Stack(r).Replace(tv,index)
-        }
+		stackage.Stack(r).Replace(tv, index)
+	}
 
-        return
+	return
 }
 
 /*
@@ -950,31 +950,31 @@ See pkg.go.dev/github.com/JesseCoretta/go-stackage#Stack.Push
 for signature and other details.
 */
 func (r MyStack) pushRequest(resp http.ResponseWriter, info updateInfo) (err error) {
-        value, found := info.Parameters[`value`]
-        if !found {
-                err = fmt.Errorf("Missing 'value' key parameter")
-                return
-        }
+	value, found := info.Parameters[`value`]
+	if !found {
+		err = fmt.Errorf("Missing 'value' key parameter")
+		return
+	}
 
-        switch tv := value.(type) {
-        case []any:
+	switch tv := value.(type) {
+	case []any:
 		if len(tv) > 0 {
 			stackage.Stack(r).Push(revEngStack(tv))
-			resp.WriteHeader(http.StatusNoContent)	// 204
+			resp.WriteHeader(http.StatusNoContent) // 204
 			return
 		}
 
-        default:
+	default:
 		if tv != nil {
 			stackage.Stack(r).Push(tv)
-			resp.WriteHeader(http.StatusNoContent)	// 204
+			resp.WriteHeader(http.StatusNoContent) // 204
 			return
 		}
-        }
+	}
 
 	http.Error(resp, "Bad request; unknown push type, or empty payload", 400)
 
-        return
+	return
 }
 
 /*
@@ -996,14 +996,14 @@ Once a stack instance is initialized, the contents of x (slices #1 and up)
 are pushed into it using the Push method.
 */
 func revEngStack(x []any) (stack any) {
-        word, _ := x[0].(string) // fallback to basic if assertion fails
+	word, _ := x[0].(string) // fallback to basic if assertion fails
 
-        switch strings.ToLower(word) {
-        case `or`, `and`, `not`, `list`:
-                stack = stackFromBooleanOperator(word)
-        default:
-                stack = stackFromBooleanOperator(`basic`)
-        }
+	switch strings.ToLower(word) {
+	case `or`, `and`, `not`, `list`:
+		stack = stackFromBooleanOperator(word)
+	default:
+		stack = stackFromBooleanOperator(`basic`)
+	}
 
 	for i := 1; i < len(x); i++ {
 		stackage.Stack(stack.(MyStack)).Push(x[i])
@@ -1019,12 +1019,12 @@ made by the user via JSON instruction payload.
 func (r MyStack) popResetOrRemoveRequest(resp http.ResponseWriter, info updateInfo) (err error) {
 	switch strings.ToLower(info.Action) {
 	case `reset`:
-                target, found := info.Parameters[`confirm`]
-                if !found {
-                        http.Error(resp, "Bad request; missing 'confirm' body parameter", 400)
-                        err = fmt.Errorf("Missing 'confirm' key parameter; this is required for 'reset'")
-                        break
-                }
+		target, found := info.Parameters[`confirm`]
+		if !found {
+			http.Error(resp, "Bad request; missing 'confirm' body parameter", 400)
+			err = fmt.Errorf("Missing 'confirm' key parameter; this is required for 'reset'")
+			break
+		}
 		assert, ok := target.(bool)
 		if !ok {
 			http.Error(resp, "Bad request; 'confirm' body parameter not a boolean", 400)
@@ -1035,10 +1035,10 @@ func (r MyStack) popResetOrRemoveRequest(resp http.ResponseWriter, info updateIn
 		if assert {
 			stackage.Stack(r).Reset()
 		}
-		resp.WriteHeader(http.StatusNoContent)	// 204
+		resp.WriteHeader(http.StatusNoContent) // 204
 
 	case `pop`:
-		var idx int = stackage.Stack(r).Len()-1
+		var idx int = stackage.Stack(r).Len() - 1
 		if stackage.Stack(r).IsFIFO() {
 			idx = 0
 		}
@@ -1050,7 +1050,7 @@ func (r MyStack) popResetOrRemoveRequest(resp http.ResponseWriter, info updateIn
 		}
 
 		var j []byte
-		if j, err = json.MarshalIndent(sliceInfo(popped,idx), "", "\t"); err != nil {
+		if j, err = json.MarshalIndent(sliceInfo(popped, idx), "", "\t"); err != nil {
 			http.Error(resp, "Internal server error", 500)
 			break
 		}
@@ -1058,12 +1058,12 @@ func (r MyStack) popResetOrRemoveRequest(resp http.ResponseWriter, info updateIn
 		fmt.Fprintln(resp, string(j))
 
 	case `remove`:
-	        target, found := info.Parameters[`idx`]
-	        if !found {
+		target, found := info.Parameters[`idx`]
+		if !found {
 			http.Error(resp, "Bad request; missing 'idx' body parameter", 400)
-	                err = fmt.Errorf("Missing 'idx' key parameter; this is required for 'remove'")
-	                break
-	        }
+			err = fmt.Errorf("Missing 'idx' key parameter; this is required for 'remove'")
+			break
+		}
 
 		assert, ok := target.(float64)
 		if !ok {
@@ -1074,10 +1074,10 @@ func (r MyStack) popResetOrRemoveRequest(resp http.ResponseWriter, info updateIn
 
 		log.Printf("---> %s", stackage.Stack(r).ID())
 		stackage.Stack(r).Remove(int(assert))
-		resp.WriteHeader(http.StatusNoContent)	// 204
+		resp.WriteHeader(http.StatusNoContent) // 204
 	}
 
-        return
+	return
 }
 
 /*
@@ -1090,17 +1090,16 @@ The fallback stack type used for invalid requests is Basic.
 func stackFromBooleanOperator(word string) (stack MyStack) {
 	switch strings.ToLower(word) {
 	case `or`:
-	        stack = MyStack(stackage.Or())
+		stack = MyStack(stackage.Or())
 	case `and`:
-	        stack = MyStack(stackage.And())
+		stack = MyStack(stackage.And())
 	case `not`:
-	        stack = MyStack(stackage.Not())
+		stack = MyStack(stackage.Not())
 	case `list`:
-	        stack = MyStack(stackage.List())
+		stack = MyStack(stackage.List())
 	default:
-	        stack = MyStack(stackage.Basic())
+		stack = MyStack(stackage.Basic())
 	}
 
 	return
 }
-

--- a/_examples/main_netstack_readwrite.go
+++ b/_examples/main_netstack_readwrite.go
@@ -121,11 +121,24 @@ hypothetical app, in essence.
 */
 func main() {
 	log.SetFlags(0)
-	stackage.SetDefaultStackLogLevel(`ALL`)
-	stackage.SetDefaultStackLogger(`stdout`)
 
-	stackage.SetDefaultConditionLogLevel(`ALL`)
-	stackage.SetDefaultConditionLogger(`stdout`)
+	// By default logging is disabled both
+	// in terms of io.Writer as well as in
+	// terms of active loglevels.
+	//
+	// Changing these settings will effect
+	// changes in log output for stdout (or
+	// whatever io.Writer a user might input
+	// by way of a custom log.Logger instance).
+	// See the docs for details.
+
+	// STACK LOGGER
+	//stackage.SetDefaultStackLogLevel(`ALL`)
+	//stackage.SetDefaultStackLogger(`stdout`)
+
+	// CONDITION LOGGER
+	//stackage.SetDefaultConditionLogLevel(`ALL`)
+	//stackage.SetDefaultConditionLogger(`stdout`)
 
 	// create signal channel to gracefully
 	// receive CTRL+C (^C) sequences. Note
@@ -151,8 +164,9 @@ func main() {
 	<-quit
 
 	// ... until you receive a signal, at which
-	// point, shutdown gracefully (Shutdown) by
-	// feeding it a background Context instance.
+	// point, terminate gracefully by feeding a
+	// Context instance to the Shutdown method
+	// designed for this demo.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	if err := stack.Shutdown(ctx); err != nil {
@@ -195,7 +209,7 @@ func MakeStack() MyStack {
 		)),
 		MyStack(stackage.And().SetID(`_random`).Push(
 			MyStack(stackage.Or().SetID(`_random`).Push(
-				stackage.Cond(`name`, stackage.Eq, `Mike`),
+				stackage.Cond(`name`, stackage.Eq, `H̷̠͙̖̜͓͍̓̑̽̒́̑̀̈̔̒̚͘͠Ė̸̢̮̟̰̭̭͖̤̠̰̙͔̺͙̝̈́̓̾͐́̋͗̋͐͆̀̄̆̅̚͜͠L̸̡̹̮͎̫̏̀̏̀͌̑̀̃͋̃̕̚͝P̴̝̑̄̆̀̈́̾͋̂̾̄͗͐͗̈̃͘͝ ̸͕͉͚̘͓̺͍̱̪̟̻̠̦͔͇̆̾͂͐̐͋͑͑̚M̴̢̧̧͍̬̰̞̖̭̫̦̣͍̩̩̘͛͆ͅE̷͔͎̩̼͂͛̃̋̊͋̋̉̉͋`),
 				stackage.Cond(`name`, stackage.Eq, `Courtney`),
 			)),
 			MyStack(stackage.Not().SetID(`negations`).Push(

--- a/cfg.go
+++ b/cfg.go
@@ -126,7 +126,7 @@ instance, if found. See also the Set method.
 
 This method internally calls the following builtin:
 
-  delete(*rcvr,key)
+	delete(*rcvr,key)
 
 Case is significant in the matching process.
 */
@@ -266,7 +266,7 @@ func (r *nodeConfig) kind() (kind string) {
 	}
 
 	switch r.typ {
-	case and, or, not, list, cond:
+	case and, or, not, list, cond, basic:
 		kind = foldValue(r.positive(cfold), r.typ.String())
 	}
 
@@ -364,12 +364,9 @@ func (r *nodeConfig) setEncap(x ...any) {
 setListDelimiter is a private method invoked by stack.setListDelimiter.
 */
 func (r *nodeConfig) setListDelimiter(x string) {
-	if !eq(r.kind(), `list`) {
-		// don't set if stack is not a list
-		return
+	if r.typ == list {
+		r.ljc = x
 	}
-
-	r.ljc = x
 }
 
 /*

--- a/cfg.go
+++ b/cfg.go
@@ -33,6 +33,7 @@ type nodeConfig struct {
 	ljc string      // [list] stacks only: joining delim
 	mtx *sync.Mutex // stacks only: optional locking system
 	ldr *time.Time  // for lock duration
+	ord bool        // true = FIFO, false = LIFO (default); applies to stacks only
 }
 
 /*

--- a/cfg.go
+++ b/cfg.go
@@ -1,7 +1,6 @@
 package stackage
 
 import (
-	"log"
 	"sync"
 	"time"
 )
@@ -23,7 +22,7 @@ type nodeConfig struct {
 	ppf PushPolicy         // closure filterer
 	vpf ValidityPolicy     // closure validator
 	rpf PresentationPolicy // closure stringer
-	log *log.Logger        // Logging subsystem
+	log *logSystem         // logging subsystem
 	opt cfgFlag            // parens, cfold, lonce, etc...
 	enc [][]string         // val encapsulators
 	err error              // error pertaining to the outer type state (Condition/Stack)
@@ -110,14 +109,6 @@ func (r nodeConfig) getErr() error {
 
 func (r *nodeConfig) setErr(err error) {
 	r.err = err
-}
-
-func (r *nodeConfig) setLogger(logger *log.Logger) {
-	r.log = logger
-}
-
-func (r nodeConfig) getLogger() *log.Logger {
-	return r.log
 }
 
 /*
@@ -462,10 +453,10 @@ func (r *nodeConfig) canWriteMessage() bool {
 	}
 
 	if r.log == nil {
-		r.log = devNull
+		r.log = newLogSystem(devNull)
 	}
 
-	return r.log != devNull
+	return r.log.log != devNull
 }
 
 func init() {

--- a/cond.go
+++ b/cond.go
@@ -27,30 +27,21 @@ The disposition of the evaluation is expressed through one (1) of
 several ComparisonOperator (op) instances made available through
 this package:
 
-• Eq, or "equal to" (=)
-
-• Ne, or "not equal to" (!=)	!! USE WITH CAUTION !!
-
-• Lt, or "less than" (<)
-
-• Le, or "less than or equal" (<=)
-
-• Gt, or "greater than" (>)
-
-• Ge, or "greater than or equal" (>=)
+  - Eq, or "equal to" (=)
+  - Ne, or "not equal to" (!=)	!! USE WITH CAUTION !!
+  - Lt, or "less than" (<)
+  - Le, or "less than or equal" (<=)
+  - Gt, or "greater than" (>)
+  - Ge, or "greater than or equal" (>=)
 
 ... OR through a user-defined operator that conforms to the package
 defined Operator interface.
 
 By default, permitted expression (ex) values must honor these guidelines:
 
-• Must be a non-zero string, OR ...
-
-• Must be a valid instance of Stack (or an *alias* of Stack that is convertible back
-to the Stack type), OR ...
-
-• Must be a valid instance of any type that exports a stringer method (String())
-intended to produce the Condition's final expression string representation
+  - Must be a non-zero string, OR ...
+  - Must be a valid instance of Stack (or an *alias* of Stack that is convertible back to the Stack type), OR ...
+  - Must be a valid instance of any type that exports a stringer method (String()) intended to produce the Condition's final expression string representation
 
 However when a PushPolicy function or method is added to an instance of this type,
 greater control is afforded to the user in terms of what values will be accepted,
@@ -195,18 +186,15 @@ default package logger.
 
 The following types/values are permitted:
 
-• string: `none`, `off`, `null`, `discard` will turn logging off *
+  - string: `none`, `off`, `null`, `discard` will turn logging off
+  - string: `stdout` will set basic STDOUT logging
+  - string: `stderr` will set basic STDERR logging
+  - int: 0 will turn logging off
+  - int: 1 will set basic STDOUT logging
+  - int: 2 will set basic STDERR logging
+  - *log.Logger: user-defined *log.Logger instance will be set; it should not be nil
 
-• string: `stderr` or `errors` will set basic stderr logging *
-
-• int: 0 will turn logging off
-
-• int: 1 will set basic stderr logging
-
-• *log.Logger: user-defined *log.Logger instance will be set; it
-should not be nil
-
-*Case is not significant in the string matching process.
+Case is not significant in the string matching process.
 
 Logging may also be set globally using the SetDefaultLogger
 package level function. Similar semantics apply.
@@ -489,13 +477,10 @@ Len returns a "perceived" abstract length relating to the content (or lack
 thereof) assigned to the receiver instance:
 
 • An uninitialized or zero instance returns zero (0)
-
 • An initialized instance with no Expression assigned (nil) returns zero (0)
+• A Stack or Stack type alias assigned as the Expression shall impose its own stack length as the return value (even if zero (0))
 
-• A Stack or Stack type alias assigned as the Expression shall impose its
-own stack length as the return value (even if zero (0)).
-
-• All other type instances assigned as an Expression shall result in a
+All other type instances assigned as an Expression shall result in a
 return of one (1); this includes slice types, maps, arrays and any other
 type that supports multiple values.
 
@@ -700,14 +685,13 @@ func (r Condition) SetPresentationPolicy(x PresentationPolicy) Condition {
 Encap accepts input characters for use in controlled condition value
 encapsulation. Acceptable input types are:
 
-• string - a single string value will be used for both L and R
-encapsulation.
+A single string value will be used for both L and R encapsulation.
 
-• string slices - An instance of []string with two (2) values will
-be used for L and R encapsulation using the first and second
-slice values respectively. An instance of []string with only one (1)
-value is identical to providing a single string value, in that both
-L and R will use one value.
+An instance of []string with two (2) values will be used for L and R
+encapsulation using the first and second slice values respectively.
+
+An instance of []string with only one (1) value is identical to the act of
+providing a single string value, in that both L and R will use one value.
 */
 func (r Condition) Encap(x ...any) Condition {
 	if r.condition == nil {

--- a/cond.go
+++ b/cond.go
@@ -366,16 +366,12 @@ func (r condition) defaultAssertionExpressionHandler(x any) (X any) {
 		// a stringer method, at least ...
 		X = x
 
-	} else if isNumberPrimitive(x) {
+	} else if isKnownPrimitive(x) {
 		// value is one of go's builtin
 		// numerical primitives, which
 		// are string represented using
 		// sprintf.
-		X = numberStringer(x)
-
-	} else if isStringPrimitive(x) {
-		// value is a simple string
-		X = x.(string)
+		X = primitiveStringer(x)
 	}
 
 	return

--- a/cond.go
+++ b/cond.go
@@ -28,7 +28,7 @@ several ComparisonOperator (op) instances made available through
 this package:
 
   - Eq, or "equal to" (=)
-  - Ne, or "not equal to" (!=)	!! USE WITH CAUTION !!
+  - Ne, or "not equal to" (!=)
   - Lt, or "less than" (<)
   - Le, or "less than or equal" (<=)
   - Gt, or "greater than" (>)
@@ -68,7 +68,7 @@ type condition struct {
 }
 
 /*
-newCondition initializes, (optionally sets) and returns a new instance of
+newCondition obtains, (optionally sets) and returns a new instance of
 *condition in one shot.
 */
 func newCondition(kw any, op Operator, ex any) (r *condition) {
@@ -81,6 +81,11 @@ func newCondition(kw any, op Operator, ex any) (r *condition) {
 	return
 }
 
+/*
+initCondition is the central initializer function for an instance
+of *condition, which is the embedded type instance found within
+(properly initialized) Condition instances.
+*/
 func initCondition() (r *condition) {
 	var data map[string]string = make(map[string]string, 0)
 
@@ -210,10 +215,15 @@ func (r Condition) SetLogger(logger any) Condition {
 }
 
 /*
-Logger returns the *log.Logger instance. It is not recommended to
-modify the return instance for the purpose of disabling logging
-outright (see Stack.SetLogger method as well as the SetDefaultLogger
-package-level function for ways of doing this easily).
+Logger returns the *log.Logger instance. This can be used for quick
+access to the log.Logger type's methods in a manner such as:
+
+	r.Logger().Fatalf("We died")
+
+It is not recommended to modify the return instance for the purpose
+of disabling logging outright (see Stack.SetLogger method as well
+as the SetDefaultConditionLogger package-level function for ways of
+doing this easily).
 */
 func (r Condition) Logger() *log.Logger {
 	if r.IsZero() {

--- a/cond.go
+++ b/cond.go
@@ -500,7 +500,7 @@ return of one (1); this includes slice types, maps, arrays and any other
 type that supports multiple values.
 
 This capability was added to this type to mirror that of the Stack type in
-order to allow additional functionality to be added to the Element interface.
+order to allow additional functionality to be added to the Interface interface.
 */
 func (r Condition) Len() int {
 	if !r.IsInit() {

--- a/cond.go
+++ b/cond.go
@@ -87,6 +87,7 @@ func initCondition() (r *condition) {
 	r = new(condition)
 	r.cfg = new(nodeConfig)
 	r.cfg.log = newLogSystem(cLogDefault)
+	r.cfg.log.lvl = logLevels(cLogLevelDefault)
 
 	r.cfg.typ = cond
 	data[`type`] = cond.String()

--- a/cond.go
+++ b/cond.go
@@ -362,7 +362,7 @@ func (r condition) defaultAssertionExpressionHandler(x any) (X any) {
 
 	// no push policy, so we'll see if the basic
 	// guidelines were satisfied, at least ...
-	if v, ok := stackTypeAliasConverter(x); ok {
+	if _, ok := stackTypeAliasConverter(x); ok {
 		if r.positive(nnest) {
 			return
 		}
@@ -370,7 +370,7 @@ func (r condition) defaultAssertionExpressionHandler(x any) (X any) {
 		// a user-created type alias of Stack
 		// was converted back to Stack without
 		// any issues ...
-		X = v
+		X = x
 
 	} else if meth := getStringer(x); meth != nil {
 		// whatever it is, it seems to have

--- a/cond_test.go
+++ b/cond_test.go
@@ -55,6 +55,7 @@ func TestCondition_001(t *testing.T) {
 
 func TestCondition_customKeyword(t *testing.T) {
 	var c Condition
+	c.Init() // always init
 	c.SetKeyword(testKeyword05)
 	c.SetOperator(Gt)
 	c.SetExpression(complex(2, 3))
@@ -72,6 +73,7 @@ func TestCondition_customType(t *testing.T) {
 	cv := customTestValue{Type: `Color`, Value: `Red`}
 
 	var c Condition
+	c.Init() // always init
 	c.SetKeyword(testKeyword05)
 	c.SetOperator(Ne)
 	c.SetExpression(cv)
@@ -105,20 +107,19 @@ func TestCondition_IsParen(t *testing.T) {
 }
 
 func TestCondition_NoNesting(t *testing.T) {
-	var c Condition
+	var c Condition = Cond(`myKeyword`, Eq, `temporary_value`)
 	c.NoNesting(true)
 
 	if c.CanNest() {
 		t.Errorf("%s failed: want '%t', got '%t'", t.Name(), false, true)
+		return
 	}
 
-	c.SetKeyword(`myKeyword`)
-	c.SetOperator(Eq)
 	c.SetExpression(And().Push(`this`, `that`))
 
 	// value should NOT have been assigned.
-	if c.Expression() != nil {
-		t.Errorf("%s failed: want '%t', got '%t' [%T]", t.Name(), false, true, c.Expression())
+	if _, asserted := c.Expression().(string); !asserted {
+		t.Errorf("%s failed: want '%t', got '%t' [%T]", t.Name(), false, asserted, c.Expression())
 	}
 }
 
@@ -132,6 +133,7 @@ func TestCondition_CanNest(t *testing.T) {
 
 func TestCondition_IsNesting(t *testing.T) {
 	var c Condition
+	c.Init() // always init
 	c.SetKeyword(`myKeyword`)
 	c.SetOperator(Eq)
 	c.SetExpression(And().Push(`this`, `that`))
@@ -165,6 +167,7 @@ func ExampleCondition_basic() {
 
 func ExampleCondition_stepByStep() {
 	var c Condition
+	c.Init() // always init
 	c.Paren()
 	c.SetKeyword(`myKeyword`)
 	c.SetOperator(Eq)

--- a/cond_test.go
+++ b/cond_test.go
@@ -159,13 +159,37 @@ func TestCondition_IsEncap(t *testing.T) {
 	}
 }
 
-func ExampleCondition_basic() {
-	c := Cond(`person`, Eq, `Jesse`).Paren().Encap(`"`).NoPadding()
+/*
+This example demonstrates the act of a one-shot creation of an instance
+of Condition using the Cond package-level function. All values must be
+non-zero/non-nil. This is useful in cases where users have all of the
+information they need and simply want to fashion a Condition quickly.
+
+Note: line-breaks added for readability; no impact on functionality,
+so long as dot sequence "connectors" (.) are honored where required.
+*/
+func ExampleCondition_oneShot() {
+	c := Cond(`person`, Eq, `Jesse`).
+		Paren().
+		Encap(`"`).
+		NoPadding()
+
 	fmt.Printf("%s", c)
 	// Output: (person="Jesse")
 }
 
-func ExampleCondition_stepByStep() {
+/*
+This example demonstrates the act of procedural assembly of an instance
+of Condition. The variable c is defined and not initialized. Its values
+are not set until "later" in the users code, and are set independently
+of one another.
+
+Note that with this technique a manual call of the Init method is always
+required as the first action following variable declaration. When using
+the "one-shot" technique by way of the Cond package-level function, the
+process of initialization is handled automatically for the user.
+*/
+func ExampleCondition_procedural() {
 	var c Condition
 	c.Init() // always init
 	c.Paren()
@@ -175,4 +199,21 @@ func ExampleCondition_stepByStep() {
 
 	fmt.Printf("%s", c)
 	// Output: ( myKeyword = value123 )
+}
+
+/*
+This example demonstrates use of the Addr method to obtain the string
+representation of the memory address for the underlying embedded receiver
+instance.
+
+NOTE: Since the address will usually be something different each runtime,
+we can't reliably test this in literal fashion, so we do a simple prefix
+check as an alternative.
+*/
+func ExampleCondition_Addr() {
+	var c Condition
+	c.Init()
+
+	fmt.Printf("Address prefix valid: %t", c.Addr()[:2] == `0x`)
+	// Address prefix valid: true
 }

--- a/doc.go
+++ b/doc.go
@@ -3,23 +3,15 @@ Package stackage implements a flexible stack type optimized for use in creating 
 
 # Features
 
-• Flexible Stack configuration controls, allowing custom presentation, push and validity policies to be executed (instead of default behavior) through the use of closure signature functions
-
-• Recursive design - Stacks can reside in Stacks. Conditions can reside in Stacks. Conditions can contain other Stacks. Whatever.
-
-• Traversible - Recursive values are easily navigated using the Stack.Traverse method
-
-• Fluent-style - types which offer methods for cumulative configuration are written in fluent-form, allowing certain commands to be optionally "chained" together
-
-• Extensible logical operator framework, allowing custom operators to be added for specialized expressions instead of the package-provided ComparisonOperator constants
-
-• MuTeX capable for each Stack instance independent of its parent or child (no recursive locking mechanisms)
-
-• Adopters may wish to create a type alias of the Condition and/or Stack types; this is particularly easy, and will not impact normal operations when dealing with nested instances of derivative types
-
-• Assertion capabilities; go beyond merely crafting the string representation of a formula -- add an Evaluator function to conduct an interrogation of a value, matching procedures, and more!
-
-• Fast, reliable, useful
+  - Flexible Stack configuration controls, allowing custom presentation, push and validity policies to be executed (instead of default behavior) through the use of closure signature functions
+  - Recursive design - Stacks can reside in Stacks. Conditions can reside in Stacks. Conditions can contain other Stacks. Whatever.
+  - Traversible - Recursive values are easily navigated using the Stack.Traverse method
+  - Fluent-style - types which offer methods for cumulative configuration are written in fluent-form, allowing certain commands to be optionally "chained" together
+  - Extensible logical operator framework, allowing custom operators to be added for specialized expressions instead of the package-provided ComparisonOperator constants
+  - MuTeX capable for each Stack instance independent of its parent or child (no recursive locking mechanisms)
+  - Adopters may wish to create a type alias of the Condition and/or Stack types; this is particularly easy, and will not impact normal operations when dealing with nested instances of derivative types
+  - Assertion capabilities; go beyond merely crafting the string representation of a formula -- add an Evaluator function to conduct an interrogation of a value, matching procedures, and more!
+  - Fast, reliable, useful
 
 # Status
 

--- a/fcf.go
+++ b/fcf.go
@@ -1,7 +1,8 @@
 package stackage
 
 /*
-fcf.go contains first-class (closure) function signature definitions.
+fcf.go contains first-class (closure) function signature and
+interface definitions.
 */
 
 /*
@@ -36,7 +37,7 @@ Stack additions, unsupported types, etc.
 A PushPolicy function or method is executed for each
 element being added to a Stack via its Push method.
 */
-type PushPolicy func(any) error
+type PushPolicy func(...any) error
 
 /*
 ValidityPolicy is a first-class (closure) function signature
@@ -46,7 +47,7 @@ validity of a stack based on its configuration and/or values.
 A ValidityPolicy function or method is executed via the Stack
 method Valid.
 */
-type ValidityPolicy func(any) error
+type ValidityPolicy func(...any) error
 
 /*
 PresentationPolicy is a first-class (closure) function signature
@@ -59,4 +60,4 @@ String method(s).
 Note that basic Stack instances are ineligible for the process of
 string representation, thus no PresentationPolicy may be set.
 */
-type PresentationPolicy func(any) string
+type PresentationPolicy func(...any) string

--- a/log.go
+++ b/log.go
@@ -40,15 +40,13 @@ this default package logger.
 
 The following types/values are permitted:
 
-• string: `none`, `off`, `null`, `discard` will turn logging off
-
-• string: `stderr` or `errors` will set basic stderr logging
-
-• int: 0 will turn logging off
-
-• int: 1 will set basic stderr logging
-
-• *log.Logger: user-defined *log.Logger instance will be set
+  - string: `none`, `off`, `null`, `discard` will turn logging off
+  - string: `stdout` will set basic STDOUT logging
+  - string: `stderr` will set basic STDERR logging
+  - int: 0 will turn logging off
+  - int: 1 will set basic STDOUT logging
+  - int: 2 will set basic STDERR logging
+  - *log.Logger: user-defined *log.Logger instance will be set
 
 Case is not significant in the string matching process.
 
@@ -73,15 +71,13 @@ this default package logger.
 
 The following types/values are permitted:
 
-• string: `none`, `off`, `null`, `discard` will turn logging off
-
-• string: `stderr` or `errors` will set basic stderr logging
-
-• int: 0 will turn logging off
-
-• int: 1 will set basic stderr logging
-
-• *log.Logger: user-defined *log.Logger instance will be set
+  - string: `none`, `off`, `null`, `discard` will turn logging off
+  - string: `stdout` will set basic STDOUT logging
+  - string: `stderr` will set basic STDERR logging
+  - int: 0 will turn logging off
+  - int: 1 will set basic STDOUT logging
+  - int: 2 will set basic STDERR logging
+  - *log.Logger: user-defined *log.Logger instance will be set
 
 Case is not significant in the string matching process.
 
@@ -97,15 +93,16 @@ func resolveLogger(logger any) (l *log.Logger) {
 	case *log.Logger:
 		l = tv
 	case int:
-		if tv == 0 {
-			l = devNull
-		} else if tv == 1 {
-			l = stderr
-		}
+		l = intResolveLogger(tv)
 	case string:
 		l = stringResolveLogger(tv)
 	}
 
+	// We need something to fallback to,
+	// regardless of the user's logging
+	// intentions; impose devNull if we
+	// find ourselves with a *log.Logger
+	// instance that is nil.
 	if l == nil || logger == nil {
 		l = devNull
 	}
@@ -113,11 +110,24 @@ func resolveLogger(logger any) (l *log.Logger) {
 	return l
 }
 
+func intResolveLogger(logger int) (l *log.Logger) {
+	switch logger {
+	case 0:
+		l = devNull
+	case 1:
+		l = stdout
+	case 2:
+		l = stderr
+	}
+
+	return
+}
+
 func stringResolveLogger(logger string) (l *log.Logger) {
 	switch lc(logger) {
 	case `none`, `off`, `null`, `discard`:
 		l = devNull
-	case `stderr`, `errors`:
+	case `stderr`:
 		l = stderr
 	case `stdout`:
 		l = stdout

--- a/log.go
+++ b/log.go
@@ -1,0 +1,248 @@
+package stackage
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+)
+
+var (
+	stdout,
+	stderr,
+	devNull,
+	sLogDefault,
+	cLogDefault *log.Logger
+)
+
+type logLevel uint16
+type logLevels uint16
+
+const (
+	logCalls  logLevel = 1 << iota // log func/meth calls and their returns
+	logPolErr                      // log errors thrown by policies, cap, r/o
+	logNCfg                        // log state changes to underlying nodeCfg
+	logInt                         // log internals (very verbose!)
+
+	logNone logLevel = 0 // log nothing
+)
+
+/*
+SetDefaultConditionLogger is a package-level function that will define
+which logging facility new instances of Condition or equivalent type
+alias shall be assigned during initialization procedures.
+
+Logging is available but is set to discard all events by default. Note
+that enabling this will have no effect on instances already created.
+
+An active logging subsystem within any given Condition shall supercede
+this default package logger.
+
+The following types/values are permitted:
+
+• string: `none`, `off`, `null`, `discard` will turn logging off
+
+• string: `stderr` or `errors` will set basic stderr logging
+
+• int: 0 will turn logging off
+
+• int: 1 will set basic stderr logging
+
+• *log.Logger: user-defined *log.Logger instance will be set
+
+Case is not significant in the string matching process.
+
+Logging may also be set for individual Condition instances using the
+SetLogger method. Similar semantics apply.
+*/
+func SetDefaultConditionLogger(logger any) {
+	cLogDefault = resolveLogger(logger)
+}
+
+/*
+SetDefaultStackLogger is a package-level function that will define
+which logging facility new instances of Stack or equivalent type
+alias shall be assigned during initialization procedures.
+
+Logging is available but is set to discard all events by default.
+Note that enabling this will have no effect on instances already
+created.
+
+An active logging subsystem within any given Stack shall supercede
+this default package logger.
+
+The following types/values are permitted:
+
+• string: `none`, `off`, `null`, `discard` will turn logging off
+
+• string: `stderr` or `errors` will set basic stderr logging
+
+• int: 0 will turn logging off
+
+• int: 1 will set basic stderr logging
+
+• *log.Logger: user-defined *log.Logger instance will be set
+
+Case is not significant in the string matching process.
+
+Logging may also be set for individual Stack instances using the
+SetLogger method. Similar semantics apply.
+*/
+func SetDefaultStackLogger(logger any) {
+	sLogDefault = resolveLogger(logger)
+}
+
+func resolveLogger(logger any) (l *log.Logger) {
+	switch tv := logger.(type) {
+	case *log.Logger:
+		l = tv
+	case int:
+		if tv == 0 {
+			l = devNull
+		} else if tv == 1 {
+			l = stderr
+		}
+	case string:
+		l = stringResolveLogger(tv)
+	}
+
+	if l == nil || logger == nil {
+		l = devNull
+	}
+
+	return l
+}
+
+func stringResolveLogger(logger string) (l *log.Logger) {
+	switch lc(logger) {
+	case `none`, `off`, `null`, `discard`:
+		l = devNull
+	case `stderr`, `errors`:
+		l = stderr
+	case `stdout`:
+		l = stdout
+	}
+
+	return
+}
+
+func logDiscard(logger *log.Logger) bool {
+	return logger.Writer() == io.Discard
+}
+
+/*
+Message is an optional type for use when a user-supplied Message channel has
+been initialized and provided to one (1) or more Stack or Condition instances.
+
+Instances of this type shall contain diagnostic, error and debug information
+pertaining to current operations of the given Stack or Condition instance.
+*/
+type Message struct {
+	ID   string             `json:"id"`
+	Msg  string             `json:"txt"`
+	Tag  string             `json:"tag"`
+	Type string             `json:"type"`
+	Addr string             `json:"addr,omitempty"`
+	Time string             `json:"time"` // YYYYMMDDhhmmss.nnnnnnnnn
+	Len  int                `json:"len"`
+	Cap  int                `json:"max_len"`
+	Data map[string]string  `json:"data,omitempty"`
+	PPol PresentationPolicy `json:"-"`
+}
+
+func (r *Message) setText(txt any) (ok bool) {
+	switch tv := txt.(type) {
+	case error:
+		if tv == nil {
+			break
+		}
+
+		r.Msg = tv.Error()
+	case string:
+		if len(tv) == 0 {
+			break
+		}
+
+		r.Msg = tv
+	}
+
+	if ok = len(r.Msg) > 0; !ok {
+		r.Msg = sprintf("Unidentified or zero debug payload (%T)", txt)
+	}
+
+	return
+}
+
+/*
+String is a stringer method that returns the string representation of
+the receiver instance. By default, this method returns JSON content.
+
+Instances of this type are used for the logging subsystem only, and do
+not serve any purpose elsewhere. Use of the logging system as a whole
+is entirely optional.
+
+Users may author their own stringer method by way of the PresentationPolicy
+closure type and override the string representation procedure for instances
+of this type (thus implementing any syntax or format they wish, i.e.: XML,
+YAML, et al).
+*/
+func (r Message) String() string {
+	if !r.Valid() {
+		return ``
+	} else if r.PPol != nil {
+		return r.PPol()
+	}
+
+	b, err := json.Marshal(&r)
+	if err != nil {
+		return ``
+	}
+
+	var replacements [][]string = [][]string{
+		{`\\u`, `\u`},
+		{`<nil>`, `nil`},
+		{` <= `, ` LE `},
+		{` >= `, ` GE `},
+		{` < `, ` LT `},
+		{` > `, ` GT `},
+		{`&&`, `SYMBOLIC_AND`},
+		{`&`, `AMPERSAND`},
+		{`||`, `SYMBOLIC_OR`},
+	}
+
+	var data string = string(b)
+	for _, repl := range replacements {
+		if str, err := uq(rplc(qt(data), repl[0], repl[1])); err == nil {
+			data = string(json.RawMessage(str))
+		}
+	}
+
+	return data
+}
+
+/*
+Valid returns a Boolean value indicative of whether the receiver
+is perceived to be valid.
+*/
+func (r Message) Valid() bool {
+	return (r.Type != `UNKNOWN` &&
+		len(r.Time) > 0 &&
+		len(r.Msg) > 0 &&
+		len(r.Tag) > 0)
+}
+
+func getLogID(elem string) (id string) {
+	id = `[no_id]`
+	if _id := elem; len(_id) > 0 {
+		id = elem
+	}
+	return
+}
+
+func init() {
+	stderr = log.New(os.Stderr, ``, 0)
+	stdout = log.New(os.Stdout, ``, 0)
+	devNull = log.New(io.Discard, ``, 0)
+	sLogDefault = devNull
+	cLogDefault = devNull
+}

--- a/log.go
+++ b/log.go
@@ -8,11 +8,20 @@ import (
 )
 
 var (
+	// io.Writer qualifiers for event dispatch
 	stdout,
 	stderr,
 	devNull,
+
+	// actual (default) logger instances, can be
+	// supplanted by users using SetDefault[X]Logger
 	sLogDefault,
 	cLogDefault *log.Logger
+
+	// actual (default) loglevel instances, can be
+	// set by users using SetDefault[X]LogLevel
+	sLogLevelDefault,
+	cLogLevelDefault LogLevel
 )
 
 type logSystem struct {
@@ -38,7 +47,10 @@ const NoLogLevels LogLevel = 0 // silent
 
 type logLevels uint16
 
-var logLevelNames map[LogLevel]string
+var (
+	logLevelNames map[LogLevel]string
+	logLevelMap   map[string]LogLevel
+)
 
 const (
 	LogLevel1      LogLevel = 1 << iota //     1 :: builtin: calls
@@ -83,17 +95,21 @@ func (r logLevels) String() string {
 
 /*
 shift shall left-shift the bit value of the receiver to include
-the addition of one (1) or more LogLevel instances (l) in variadic
-fashion.
+the addition of one (1) or more LogLevel specifiers (l) in variadic
+fashion. Type instances that qualify are as follows:
+
+  - string (case-insensitive loglevel "name", e.g.: "trace" or "none")
+  - LogLevel (actual LogLevel constants, e.g.: NoLoglevels or LogLevel3)
 
 If any of l's values are NoLogLevels, the receiver shall be set to
 zero (0) and any remaining shifts shall be discarded. In this context,
-"shift nothing" translates to "log nothing".
+"shift zero" translates to "log nothing".
 
-Conversely, if any of l's values are LogLevel16, the receiver shall be set
-to ^LogLevel(0) (uint16(65535)) and any remaining shifts shall be discarded.
+Conversely, if any of l's values are LogLevel16, the receiver shall be
+set to ^LogLevel(0) (uint16(65535)) and any remaining shifts shall be
+discarded. Predictably, "shift 65535" translates to "log everything".
 */
-func (r *logSystem) shift(l ...LogLevel) *logSystem {
+func (r *logSystem) shift(l ...any) *logSystem {
 	if r == nil {
 		r = newLogSystem(devNull)
 	}
@@ -101,17 +117,54 @@ func (r *logSystem) shift(l ...LogLevel) *logSystem {
 	return r
 }
 
-func (r *logLevels) shift(l ...LogLevel) *logLevels {
+/*
+shift is a private method called by instances of the
+logSystem struct type, et al.
+*/
+func (r *logLevels) shift(l ...any) *logLevels {
 	for i := 0; i < len(l); i++ {
-		if l[i] == NoLogLevels {
+		var ll LogLevel // current iteration's resolved loglevel stored here
+
+		// Perform type-switch upon the
+		// currently iterated 'any' (#i)
+		switch tv := l[i].(type) {
+
+		case string:
+			// value could be a loglevel NAME. Try to
+			// resolve it, and pay no regard to case
+			// folding.
+			var found bool
+			if ll, found = logLevelMap[uc(tv)]; !found {
+				continue
+			}
+
+		case LogLevel:
+			// value is a LogLevel instance. Just take
+			// it at face value.
+			ll = tv
+		default:
+			// no other types make sense for support,
+			// so skip to the next iteration.
+			continue
+		}
+
+		if ll == NoLogLevels {
+			// clobber loglevel with zero (0) and
+			// ditch remaining iteration(s).
 			*r = logLevels(NoLogLevels)
 			return r
-		} else if l[i] == AllLogLevels {
+		} else if ll == AllLogLevels {
+			// clobber loglevel with ^uint16(0) (max)
+			// and ditch remaining iteration(s).
 			*r = logLevels(AllLogLevels)
 			return r
 		}
 
-		*r |= logLevels(l[i])
+		// Loglevel is neither "all" nor "none",
+		// meaning is a singular, discrete log
+		// verbosity specifier; shift it into
+		// current value, don't clobber.
+		*r |= logLevels(ll)
 	}
 
 	return r
@@ -130,7 +183,7 @@ If any of l's values are LogLevel16, the receiver shall be set to zero
 (0) and any remaining shifts shall be discarded, as "unshift all"
 in this context translates to "log nothing".
 */
-func (r *logSystem) unshift(l ...LogLevel) *logSystem {
+func (r *logSystem) unshift(l ...any) *logSystem {
 	if r.isZero() {
 		r = newLogSystem(devNull)
 		return r
@@ -140,16 +193,37 @@ func (r *logSystem) unshift(l ...LogLevel) *logSystem {
 	return r
 }
 
-func (r *logLevels) unshift(l ...LogLevel) *logLevels {
+func (r *logLevels) unshift(l ...any) *logLevels {
 	for i := 0; i < len(l); i++ {
-		if LogLevel(l[i]) == NoLogLevels {
+		var ll LogLevel
+		switch tv := l[i].(type) {
+		case string:
+			// value could be a loglevel NAME. Try to
+			// resolve it, and pay no regard to case
+			// folding.
+			var found bool
+			if ll, found = logLevelMap[uc(tv)]; !found {
+				continue
+			}
+
+		case LogLevel:
+			// value is a LogLevel instance. Just take
+			// it at face value.
+			ll = tv
+		default:
+			// no other types make sense for support,
+			// so skip to the next iteration.
+			continue
+		}
+
+		if ll == NoLogLevels {
 			continue // WAT.
-		} else if LogLevel(l[i]) == AllLogLevels {
-			*r = logLevels(AllLogLevels)
+		} else if ll == AllLogLevels {
+			*r = logLevels(ll)
 			return r
 		}
 
-		*r = (*r &^ logLevels(l[i]))
+		*r = (*r &^ logLevels(ll))
 	}
 	return r
 }
@@ -159,7 +233,7 @@ positive returns a Boolean value indicative of whether the receiver
 contains the bit value for the specified logLevel. In context, this
 means "logLevel <X>" is either active (true) or not (false).
 */
-func (r logSystem) positive(l LogLevel) bool {
+func (r logSystem) positive(l any) bool {
 	if r.isZero() {
 		return false
 	}
@@ -167,14 +241,33 @@ func (r logSystem) positive(l LogLevel) bool {
 	return r.lvl.positive(l)
 }
 
-func (r logLevels) positive(l LogLevel) bool {
+func (r logLevels) positive(l any) bool {
 	if r == logLevels(0) {
 		return false
 	} else if r == ^logLevels(0) {
 		return true
 	}
 
-	result := (r & logLevels(l)) != 0
+	var ll LogLevel
+	switch tv := l.(type) {
+	case string:
+		// value could be a loglevel NAME. Try to
+		// resolve it, and pay no regard to case
+		// folding.
+		var found bool
+		if ll, found = logLevelMap[uc(tv)]; !found {
+			return false
+		}
+
+	case LogLevel:
+		// value is a LogLevel instance. Just take
+		// it at face value.
+		ll = tv
+	default:
+		return false
+	}
+
+	result := (r & logLevels(ll)) != 0
 
 	return result
 }
@@ -200,7 +293,7 @@ func (r *logSystem) setLogger(logger any) *logSystem {
 	return r
 }
 
-func newLogSystem(logger any, l ...LogLevel) (lsys *logSystem) {
+func newLogSystem(logger any, l ...any) (lsys *logSystem) {
 	lgr := devNull
 	if logger != nil {
 		lgr = resolveLogger(logger)
@@ -243,6 +336,41 @@ func SetDefaultConditionLogger(logger any) {
 }
 
 /*
+SetDefaultConditionLogLevel sets the instance of LogLevel (lvl)
+as a LITERAL value, as the verbosity indicator. When set with
+appropriate level identifiers, this will increase or decrease
+log verbosity accordingly. This value shall be used for logging
+verbosity (or lack thereof) for any newly created (and qualified)
+instances.
+
+Note that the input value(s) are NOT shifted. Users are expected
+to either sum the values and cast the product as a LogLevel, OR
+settle for one of the predefined LogLevel constants.
+
+The default is NoLogLevels, which implies a loglevel of zero (0).
+*/
+func SetDefaultConditionLogLevel(lvl any) {
+	var level LogLevel
+	switch tv := lvl.(type) {
+	case string:
+		ll, found := logLevelMap[uc(tv)]
+		if found {
+			level = ll
+		}
+	case int:
+		if 0 <= tv && tv <= int(^uint16(0)) {
+			level = LogLevel(tv)
+		}
+	case LogLevel:
+		level = tv
+	default:
+		level = NoLogLevels
+	}
+
+	cLogLevelDefault = level
+}
+
+/*
 SetDefaultStackLogger is a package-level function that will define
 which logging facility new instances of Stack or equivalent type
 alias shall be assigned during initialization procedures.
@@ -271,6 +399,42 @@ SetLogger method. Similar semantics apply.
 */
 func SetDefaultStackLogger(logger any) {
 	sLogDefault = resolveLogger(logger)
+}
+
+/*
+SetDefaultStackLogLevel sets the instance of LogLevel (lvl)
+as a LITERAL value, as the verbosity indicator. When set with
+appropriate level identifiers, this will increase or decrease
+log verbosity accordingly. This value shall be used for logging
+verbosity (or lack thereof) for any newly created (and qualified)
+instances.
+
+Note that the input value(s) are NOT shifted. Users are expected
+to either sum the values and cast the product as a LogLevel, OR
+settle for one of the predefined LogLevel constants.
+
+The default is NoLogLevels, which implies a loglevel of zero
+(0).
+*/
+func SetDefaultStackLogLevel(lvl any) {
+	var level LogLevel
+	switch tv := lvl.(type) {
+	case string:
+		ll, found := logLevelMap[uc(tv)]
+		if found {
+			level = ll
+		}
+	case int:
+		if 0 <= tv && tv <= int(^uint16(0)) {
+			level = LogLevel(tv)
+		}
+	case LogLevel:
+		level = tv
+	default:
+		level = NoLogLevels
+	}
+
+	sLogLevelDefault = level
 }
 
 func resolveLogger(logger any) (l *log.Logger) {
@@ -438,16 +602,23 @@ func init() {
 	stderr = log.New(os.Stderr, ``, 0)
 	stdout = log.New(os.Stdout, ``, 0)
 	devNull = log.New(io.Discard, ``, 0)
+
+	// log events dispatched into oblivion
 	sLogDefault = devNull
 	cLogDefault = devNull
 
+	// log events are ignored regardless of severity/category
+	sLogLevelDefault = NoLogLevels
+	cLogLevelDefault = NoLogLevels
+
+	// instance->str
 	logLevelNames = map[LogLevel]string{
 		NoLogLevels:    `NONE`,
 		LogLevel1:      `CALLS`,
 		LogLevel2:      `POLICY`,
 		LogLevel3:      `STATE`,
 		LogLevel4:      `DEBUG`,
-		LogLevel5:      `ERRORS`,
+		LogLevel5:      `ERROR`,
 		LogLevel6:      `TRACE`,
 		UserLogLevel1:  `USER1`,
 		UserLogLevel2:  `USER2`,
@@ -460,5 +631,27 @@ func init() {
 		UserLogLevel9:  `USER9`,
 		UserLogLevel10: `USER10`,
 		AllLogLevels:   `ALL`,
+	}
+
+	// str->instance
+	logLevelMap = map[string]LogLevel{
+		`NONE`:   NoLogLevels,
+		`CALLS`:  LogLevel1,
+		`POLICY`: LogLevel2,
+		`STATE`:  LogLevel3,
+		`DEBUG`:  LogLevel4,
+		`ERROR`:  LogLevel5,
+		`TRACE`:  LogLevel6,
+		`USER1`:  UserLogLevel1,
+		`USER2`:  UserLogLevel2,
+		`USER3`:  UserLogLevel3,
+		`USER4`:  UserLogLevel4,
+		`USER5`:  UserLogLevel5,
+		`USER6`:  UserLogLevel6,
+		`USER7`:  UserLogLevel7,
+		`USER8`:  UserLogLevel8,
+		`USER9`:  UserLogLevel9,
+		`USER10`: UserLogLevel10,
+		`ALL`:    AllLogLevels,
 	}
 }

--- a/misc.go
+++ b/misc.go
@@ -62,7 +62,7 @@ func timestamp() string {
 }
 
 func isETravEligible(ok bool, x any) bool {
-	return ( isIntKeyedMap(x) || isSliceType(x) ) && ok
+	return (isIntKeyedMap(x) || isSliceType(x)) && ok
 }
 
 func isIntKeyedMap(x any) bool {

--- a/misc.go
+++ b/misc.go
@@ -265,6 +265,10 @@ type instance's String ("stringer") method, if present.
 If not, nil is returned.
 */
 func getStringer(x any) func() string {
+	if x == nil {
+		return nil
+	}
+
 	v := valOf(x)
 	if v.IsZero() {
 		return nil

--- a/misc.go
+++ b/misc.go
@@ -541,23 +541,135 @@ Users SHOULD adopt this interface signature for use in their solutions
 if and when needed, though it is not a requirement.
 */
 type Interface interface {
+	// Stack: Len returns an integer that represents the number of
+	// slices present within.
+	//
+	// Condition: Len returns a one (1) if properly initialized
+	// and set with a value that is not a Stack. Len returns a
+	// zero (0) if invalid or otherwise not properly initialized.
+	// Len returns the value of Stack.Len in deference, should the
+	// expression itself be a Stack.
 	Len() int
 
+	// IsInit returns a Boolean value indicative of whether the
+	// receiver instance is considered 'properly initialized'
 	IsInit() bool
+
+	// Stack: IsFIFO returns a Boolean value indicative of whether
+	// the Stack instance exhibits First-In-First-Out behavior as it
+	// pertains to the ingress and egress order of slices. See the
+	// Stack.SetFIFO method for details on setting this behavior.
+	//
+	// Condition: IsFIFO returns a Boolean value indicative of whether
+	// the receiver's Expression value contains a Stack instance AND
+	// that Stack exhibits First-In-First-Out behavior as it pertains
+	// to the ingress and egress order of slices. If no Stack value is
+	// present within the Condition, false is always returned.
+	IsFIFO() bool
+
+	// IsZero returns a Boolean value indicative of whether the receiver
+	// instance is considered nil, or unset.
 	IsZero() bool
+
+	// Stack: CanNest returns a Boolean value indicative of whether the
+	// receiver is allowed to append (Push) additional Stack instances
+	// into its collection of slices.
+	//
+	// Condition: CanNest returns a Boolean value indicative of whether
+	// the receiver is allowed to set a Stack instance as its Expression
+	// value.
+	//
+	// See also the NoNesting and IsNesting methods for either of these
+	// types.
 	CanNest() bool
+
+	// IsParen returns a Boolean value indicative of whether the receiver
+	// instance, when represented as a string value, shall encapsulate in
+	// parenthetical L [(] and R [)] characters.
+	//
+	// See also the Paren method for Condition and Stack instances.
 	IsParen() bool
+
+	// IsEncap returns a Boolean value indicative of whether the receiver
+	// instance, when represented as a string value, shall encapsulate the
+	// effective value within user-defined quotation characters.
+	//
+	// See also the Encap method for Condition and Stack instances.
 	IsEncap() bool
+
+	// Stack: IsPadded returns a Boolean value indicative of whether WHSP
+	// (ASCII #32) padding shall be applied to the outermost ends of the
+	// string representation of the receiver (but within parentheticals).
+	//
+	// Condition: IsPadded returns a Boolean value indicative of whether
+	// WHSP (ASCII #32) padding shall be applied to the outermost ends of
+	// the string representation of the receiver, as well as around it's
+	// comparison operator, when applicable.
+	//
+	// See also the NoPadding method for either of these types.
 	IsPadded() bool
+
+	// Stack: IsNesting returns a Boolean value indicative of whether the
+	// receiver contains one (1) or more slices that are Stack instances.
+	//
+	// Condition: IsNesting returns a Boolean value indicative of whether
+	// the Expression value set within the receiver is a Stack instance.
+	//
+	// See also the NoNesting and CanNest method for either of these types.
 	IsNesting() bool
 
+	// ID returns the identifier assigned to the receiver, if set. This
+	// may be anything the user chooses to set, or it may be auto-assigned
+	// using the `_addr` or `_random` input keywords.
+	//
+	// See also the SetID method for Condition and Stack instances.
 	ID() string
+
+	// Addr returns the string representation of the pointer address of
+	// the embedded receiver instance. This is mainly useful in cases
+	// where debugging/troubleshooting may be underway, and the ability
+	// to distinguish unnamed instances would be beneficial. It may also
+	// be used as an alternative to the tedium of manually naming objects.
 	Addr() string
+
+	// String returns the string representation of the receiver. Note that
+	// if the receiver is a BASIC Stack, string representation shall not be
+	// possible.
 	String() string
+
+	// Stack: Category returns the categorical string label assigned to the
+	// receiver instance during initialization. This will be one of AND, OR,
+	// NOT, LIST and BASIC (these values may be folded case-wise depending
+	// on the state of the Fold bit, as set by the user).
+	//
+	// Condition: Category returns the categorical string label assigned to
+	// the receiver instance by the user at any time. Condition categorical
+	// labels are entirely user-controlled.
+	//
+	// See also the SetCategory method for either of these types.
 	Category() string
 
+	// Err returns the most recently set instance of error within the receiver.
+	// This is particularly useful for users who dislike fluent-style method
+	// execution and would prefer to operate in the traditional "if err != nil ..."
+	// style.
+	//
+	// See also the SetErr method for Condition and Stack instances.
 	Err() error
+
+	// Valid returns an instance of error resulting from a cursory review of the
+	// receiver without any special context. Nilness, quality-of-initialization
+	// and other rudiments are checked.
+	//
+	// This method is most useful when users apply a ValidityPolicy method or
+	// function to the receiver instance, allowing full control over what they
+	// deem "valid". See the SetValidityPolicy method for Condition and Stack
+	// instances for details.
 	Valid() error
 
+	// Logger returns the underlying instance of *log.Logger, which may be set by
+	// the package by defaults, or supplied by the user in a piecemeal manner.
+	//
+	// See also the SetLogger method for Condition and Stack instances.
 	Logger() *log.Logger
 }

--- a/misc.go
+++ b/misc.go
@@ -455,11 +455,10 @@ func intStringer(x any) string {
 
 /*
 Interface is an interface type qualified through instances of the
-following types:
+following types (whether native, or type-aliased):
 
-• Stack
-
-• Condition
+  - Stack
+  - Condition
 
 This interface type offers users an alternative to the tedium of
 repeated type assertion for every Stack and Condition instance they
@@ -470,13 +469,13 @@ myriad hierarchies and nested contexts of varying types.
 This is not a complete "replacement" for the explicit use of package
 defined types nor their aliased counterparts. The Interface interface
 only extends methods that are read-only in nature AND common to both
-of the above types (and any aliased counterparts).
+of the above categories.
 
 To access the entire breadth of available methods for the underlying
 type instance, manual type assertion shall be necessary.
 
 Users SHOULD adopt this interface signature for use in their solutions
-as needed, though it is not strictly required.
+if and when needed, though it is not a requirement.
 */
 type Interface interface {
 	Len() int

--- a/misc.go
+++ b/misc.go
@@ -454,7 +454,7 @@ func intStringer(x any) string {
 }
 
 /*
-Element is an interface type qualified through instances of the
+Interface is an interface type qualified through instances of the
 following types:
 
 • Stack
@@ -468,7 +468,7 @@ act of traversal is conducted upon a Stack instance that contains
 myriad hierarchies and nested contexts of varying types.
 
 This is not a complete "replacement" for the explicit use of package
-defined types nor their aliased counterparts. The Element interface
+defined types nor their aliased counterparts. The Interface interface
 only extends methods that are read-only in nature AND common to both
 of the above types (and any aliased counterparts).
 
@@ -478,7 +478,7 @@ type instance, manual type assertion shall be necessary.
 Users SHOULD adopt this interface signature for use in their solutions
 as needed, though it is not strictly required.
 */
-type Element interface {
+type Interface interface {
 	Len() int
 
 	IsInit() bool

--- a/misc.go
+++ b/misc.go
@@ -490,6 +490,7 @@ type Interface interface {
 	IsNesting() bool
 
 	ID() string
+	Addr() string
 	String() string
 	Category() string
 

--- a/misc.go
+++ b/misc.go
@@ -493,6 +493,7 @@ type Interface interface {
 	String() string
 	Category() string
 
+	Err() error
 	Valid() error
 
 	Logger() *log.Logger

--- a/op.go
+++ b/op.go
@@ -55,17 +55,12 @@ ComparisonOperator is a uint8 enumerated type used for abstract
 representation of the following well-known and package-provided
 operators:
 
-• Equal (=)
-
-• Not Equal (!=)
-
-• Less Than (<)
-
-• Greater Than (>)
-
-• Less Than Or Equal (<=)
-
-• Greater Than Or Equal (>=)
+  - Equal (=)
+  - Not Equal (!=)
+  - Less Than (<)
+  - Greater Than (>)
+  - Less Than Or Equal (<=)
+  - Greater Than Or Equal (>=)
 
 Instances of this type should be passed to Cond as the 'op' value.
 */

--- a/stack.go
+++ b/stack.go
@@ -2002,7 +2002,7 @@ func (r *stack) revealDescend(inner Stack, idx int) (err error) {
 			// descend into inner slice #0
 			child, _, _ := inner.index(0)
 			cid := getLogID(``)
-			assert, ok := child.(Element)
+			assert, ok := child.(Interface)
 			if ok {
 				cid = getLogID(assert.ID())
 			}
@@ -2134,7 +2134,7 @@ func (r stack) traverseStackInCondition(u any, idx int, indices ...int) (slice a
 			// Stack *OR* a Stack alias, traverse it ...
 			expr := c.Expression()
 			var id string = getLogID(``)
-			if assert, aok := expr.(Element); aok {
+			if assert, aok := expr.(Interface); aok {
 				id = getLogID(assert.ID())
 			}
 			r.debug(sprintf("%s: descending into %T:%d:%s at %v", fname, expr, idx, id, indices))

--- a/stack.go
+++ b/stack.go
@@ -61,8 +61,8 @@ for string representation, value encaps, delimitation, and
 other presentation-related string methods. As such, a zero
 string (“) shall be returned should String() be executed.
 
-PresentationPolicy instances cannot be assigned to Stacks
-of this design.
+PresentationPolicy instances cannot be assigned to Stack
+instances of this design.
 */
 func Basic(capacity ...int) Stack {
 	return Stack{newStack(basic, false, capacity...)}
@@ -72,7 +72,8 @@ func Basic(capacity ...int) Stack {
 newStack initializes a new instance of *stack, configured
 with the kind (t) requested by the user. This function
 should only be executed when creating new instances of
-Stack, which embeds the *stack type.
+Stack (or a Stack type alias), which embeds the *stack
+type instance.
 */
 func newStack(t stackType, fifo bool, c ...int) *stack {
 	switch t {
@@ -87,6 +88,7 @@ func newStack(t stackType, fifo bool, c ...int) *stack {
 		cfg  *nodeConfig       = new(nodeConfig)
 		st   stack
 	)
+
 	cfg.log = newLogSystem(sLogDefault)
 	cfg.log.lvl = logLevels(sLogLevelDefault)
 
@@ -625,8 +627,8 @@ access to the log.Logger type's methods in a manner such as:
 
 It is not recommended to modify the return instance for the purpose
 of disabling logging outright (see Stack.SetLogger method as well
-as the SetDefaultLogger package-level function for ways of doing
-this easily).
+as the SetDefaultStackLogger package-level function for ways of
+doing this easily).
 */
 func (r Stack) Logger() *log.Logger {
 	if !r.IsInit() {
@@ -638,7 +640,7 @@ func (r Stack) Logger() *log.Logger {
 
 /*
 Transfer will iterate the receiver (r) and add all slices
-contained therein to the destination instance.
+contained therein to the destination instance (dest).
 
 The following circumstances will result in a false return:
 
@@ -647,10 +649,11 @@ The following circumstances will result in a false return:
   - The receiver instance (r) contains no slices to transfer
 
 The receiver instance (r) is not modified in any way as a
-result of calling this method. If the receiver undergoes a
-call to its Reset() method, only the receiver instance will
-be emptied, and the transferred slices within the submitted
-destination instance shall remain.
+result of calling this method. If the receiver (source) should
+undergo a call to its Reset() method following a call to the
+Transfer method, only the source will be emptied, and of the
+slices that have since been transferred instance shall remain
+in the destination instance.
 */
 func (r Stack) Transfer(dest Stack) bool {
 	return r.transfer(dest.stack)
@@ -2416,7 +2419,7 @@ a success-indicative Boolean value.
 The semantics of "traversability" are as follows:
 
   - Any "nesting" instance must be a Stack or Stack type alias
-  - Condition instances must either be the final requested element, OR must contain a Stack or Stack type alias instance through which to continue the traversal process
+  - Condition instances must either be the final requested element, OR must contain a Stack or Stack type alias instance through which the traversal process may continue
   - All other value types are returned as-is
 
 If the traversal ended at any given value, it will be returned along with a
@@ -2424,8 +2427,7 @@ positive ok value letting the user know they arrived at the coordinates they
 defined and that "something" was found.
 
 If, however, any path elements remained and further traversal was NOT possible,
-the last slice is returned but ok is not set positive, thereby letting the user
-know they took a wrong turn somewhere.
+the last slice is returned as nil.
 
 As the return type is any, the slice value must be manually type asserted.
 */
@@ -2712,7 +2714,7 @@ func (r stack) traverseAssertionHandler(x any, idx int, indices ...int) (slice a
 		slice = x
 		ok = true
 		done = true
-		r.debug(sprintf("%s: idx %d: found slice %T at end of path",
+		r.debug(sprintf("%s: idx %d: found target slice %T at end of path",
 			fname, idx, x))
 	} else {
 		// If we arrived here with more path elements left,

--- a/stack.go
+++ b/stack.go
@@ -2551,7 +2551,7 @@ func (r *stack) reveal() (err error) {
 }
 
 /*
-revealDescent is a private method called by stack.reveal. It engages the second
+revealDescend is a private method called by stack.reveal. It engages the second
 level of processing of the provided inner Stack instance.
 
 Its first order of business is to determine the length of the inner Stack instance
@@ -2576,8 +2576,7 @@ func (r *stack) revealDescend(inner Stack, idx int) (err error) {
 
 	id := getLogID(r.getID())
 
-	// TODO: Still mulling the best way
-	// to handle NOTs.
+	// TODO: Still mulling the best way to handle NOTs.
 	if inner.stackType() != not {
 		switch inner.Len() {
 		case 0:
@@ -2592,26 +2591,34 @@ func (r *stack) revealDescend(inner Stack, idx int) (err error) {
 			if ok {
 				cid = getLogID(assert.ID())
 			}
+			if assert.IsParen() || inner.IsParen() {
+				break
+			}
 
 			r.trace(sprintf("%s: descending into single idx:%d %T::%s",
 				fname, 0, child, cid))
-			if err = r.revealSingle(0); err != nil {
-				r.error(sprintf("%s: %T::%s %v",
-					fname, child, cid, err))
-				break
-			}
+
+			err = r.revealSingle(0)
+
+			r.error(sprintf("%s: %T::%s %v",
+				fname, child, cid, err))
+
 			updated = child
 		default:
 			// begin new top-level reveal of inner
 			// as a whole, scanning all +2 slices
 			r.trace(sprintf("%s: descending into %T::%s",
 				fname, 0, inner, id))
-			if err = inner.reveal(); err != nil {
-				r.error(sprintf("%s: %T::%s %v",
-					fname, inner, id, err))
-				break
-			}
+
+			err = inner.reveal()
+
+			r.error(sprintf("%s: %T::%s %v",
+				fname, inner, id, err))
 			updated = inner
+		}
+
+		if err != nil {
+			return
 		}
 	}
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -19,30 +19,36 @@ func ExampleStack_SetAuxiliary() {
 	// Always alloc stack somehow, in this
 	// case just use List because its simple
 	// and (unlike Basic) it is feature-rich.
-        var list Stack = List()
+	var list Stack = List()
 
-        // alloc map
-        aux := make(Auxiliary,0)
+	// alloc map
+	aux := make(Auxiliary, 0)
 
-        // populate map
-        aux.Set(`somethingWeNeed`, struct{
-                Type string
-                Value []string
-        }{
-                Type: `L`,
-                Value: []string{
-                        `abc`,
-                        `def`,
-                },
-        })
+	// populate map
+	aux.Set(`somethingWeNeed`, struct {
+		Type  string
+		Value []string
+	}{
+		Type: `L`,
+		Value: []string{
+			`abc`,
+			`def`,
+		},
+	})
 
-        // assign map to stack rcvr
-        list.SetAuxiliary(aux)
+	// assign map to stack rcvr
+	list.SetAuxiliary(aux)
 
 	// verify presence
-        call := list.Auxiliary()
+	call := list.Auxiliary()
 	fmt.Printf("%T found, length:%d", call, call.Len())
 	// Output: stackage.Auxiliary found, length:1
+}
+
+func ExampleStack_Kind() {
+	var myStack Stack = And()
+	fmt.Printf("Kind: '%s'", myStack.Kind())
+	// Output: Kind: 'AND'
 }
 
 /*
@@ -55,11 +61,11 @@ UserInit or ByTypeCast examples.
 */
 func ExampleStack_Auxiliary_noInit() {
 
-        var list Stack = List()
-        aux := list.Auxiliary()
-        fmt.Printf("%T found, length:%d",
-		aux, aux.Set(`testing`,`123`).Len())
-        // Output: stackage.Auxiliary found, length:0
+	var list Stack = List()
+	aux := list.Auxiliary()
+	fmt.Printf("%T found, length:%d",
+		aux, aux.Set(`testing`, `123`).Len())
+	// Output: stackage.Auxiliary found, length:0
 }
 
 /*
@@ -69,13 +75,13 @@ outcome is achieved.
 */
 func ExampleStack_Auxiliary_withInit() {
 
-        var list Stack = List().SetAuxiliary() // no args triggers auto-init
-        aux := list.Auxiliary()
-        fmt.Printf("%T found, length was:%d, is now:%d",
-                aux,
-		aux.Len(),			// check initial (pre-set) length
-		aux.Set(`testing`,`123`).Len())	// fluent Set/Len in one shot
-        // Output: stackage.Auxiliary found, length was:0, is now:1
+	var list Stack = List().SetAuxiliary() // no args triggers auto-init
+	aux := list.Auxiliary()
+	fmt.Printf("%T found, length was:%d, is now:%d",
+		aux,
+		aux.Len(),                       // check initial (pre-set) length
+		aux.Set(`testing`, `123`).Len()) // fluent Set/Len in one shot
+	// Output: stackage.Auxiliary found, length was:0, is now:1
 }
 
 /*
@@ -85,19 +91,19 @@ populated by the user in a traditional fashion.
 */
 func ExampleStack_Auxiliary_userInit() {
 
-        var list Stack = List()
+	var list Stack = List()
 	aux := make(Auxiliary, 0)
 
 	// user opts to just use standard map
 	// key/val set procedure, and avoids
 	// use of the convenience methods.
 	// This is totally fine.
-	aux[`value1`] = []int{1,2,3,4,5}
+	aux[`value1`] = []int{1, 2, 3, 4, 5}
 	aux[`value2`] = [2]any{float64(7.014), rune('#')}
 
 	list.SetAuxiliary(aux)
-        fmt.Printf("%T length:%d", aux, len(aux))
-        // Output: stackage.Auxiliary length:2
+	fmt.Printf("%T length:%d", aux, len(aux))
+	// Output: stackage.Auxiliary length:2
 }
 
 /*
@@ -106,25 +112,25 @@ form (map[string]any) before being type cast to Auxiliary.
 */
 func ExampleStack_Auxiliary_byTypeCast() {
 
-        var list Stack = List()
-        proto := make(map[string]any, 0)
-        proto[`value1`] = []int{1,2,3,4,5}
-        proto[`value2`] = [2]any{float64(7.014), rune('#')}
-        list.SetAuxiliary(Auxiliary(proto))	// cast proto and assign to stack
-	aux := list.Auxiliary()			// call map to variable
-        fmt.Printf("%T length:%d", aux, aux.Len())
-        // Output: stackage.Auxiliary length:2
+	var list Stack = List()
+	proto := make(map[string]any, 0)
+	proto[`value1`] = []int{1, 2, 3, 4, 5}
+	proto[`value2`] = [2]any{float64(7.014), rune('#')}
+	list.SetAuxiliary(Auxiliary(proto)) // cast proto and assign to stack
+	aux := list.Auxiliary()             // call map to variable
+	fmt.Printf("%T length:%d", aux, aux.Len())
+	// Output: stackage.Auxiliary length:2
 }
 
 func TestStack_SetAuxiliary(t *testing.T) {
 	var list Stack = List()
 
 	// alloc map
-	aux := make(Auxiliary,0)
+	aux := make(Auxiliary, 0)
 
 	// populate map
-	aux.Set(`somethingWeNeed`, struct{
-		Type string
+	aux.Set(`somethingWeNeed`, struct {
+		Type  string
 		Value []string
 	}{
 		Type: `L`,
@@ -958,7 +964,8 @@ func TestStack_Reveal_experimental001(t *testing.T) {
 
 func TestDefrag_experimental_001(t *testing.T) {
 	// this list contains an assortment of
-	// values mixed in with nils.
+	// values mixed in with nils and a couple
+	// hierarchies tossed in, too.
 	var l Stack = List().SetLogLevel(LogLevel(45)).Push(
 		`this`,
 		nil,
@@ -966,7 +973,12 @@ func TestDefrag_experimental_001(t *testing.T) {
 		nil,
 		`those`,
 		nil,
-		nil,
+		List().Push(
+			nil, nil, nil, `other`, `level`, `of`, nil, nil, `stuff`,
+			And().Push(
+				`yet`, nil, nil, nil, nil, `more`, `JUNK`,
+			),
+		),
 		nil,
 		nil,
 		nil,

--- a/stack_test.go
+++ b/stack_test.go
@@ -892,14 +892,14 @@ func TestStack_Reveal_experimental001(t *testing.T) {
 						Cond(`dayofweek`, Ne, "Wednesday"),
 						Cond(`ssf`, Ge, "128"),
 					),
-				).Paren(),
+				),
 			),
 			And().Push(
 				Or().Push(
 					Cond(`keyword2`, Lt, "someothervalue"),
 				),
 			),
-		).Paren(),
+		),
 		`this2`,
 	)
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -660,8 +660,8 @@ func ExampleStack_Delimiter() {
 	// Output: ,
 }
 
-func TestElement(t *testing.T) {
-	var elem Element
+func TestInterface(t *testing.T) {
+	var elem Interface
 	elem = Cond(`greeting`, Eq, `Hello`)
 	want := `greeting = Hello`
 	got := elem.String()

--- a/stack_test.go
+++ b/stack_test.go
@@ -785,7 +785,7 @@ func TestStack_Reveal_experimental001(t *testing.T) {
 func TestDefrag_experimental_001(t *testing.T) {
 	// this list contains an assortment of
 	// values mixed in with nils.
-	var l Stack = List().Push(
+	var l Stack = List().SetLogLevel(LogLevel(45)).Push(
 		`this`,
 		nil,
 		`that`,
@@ -813,7 +813,7 @@ func TestDefrag_experimental_001(t *testing.T) {
 		nil,
 		nil,
 		nil,
-	)
+	).Paren()
 
 	offset := 13         // number of nil occurrences
 	beforeLen := l.Len() // record preop len
@@ -837,6 +837,6 @@ func TestDefrag_experimental_001(t *testing.T) {
 }
 
 func init() {
-	//SetDefaultStackLogger(`stdout`)
+	SetDefaultStackLogger(`stdout`)
 	//SetDefaultConditionLogger(`stdout`)
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -602,6 +602,35 @@ func ExampleBasic_setAsReadOnly() {
 	// Output: first try: 2 vs. second try: 1
 }
 
+func ExampleStack_Pop_lIFO() {
+	b := Basic()
+	b.Push(
+		float64(3.14159),
+		float32(-9.378),
+		-1,
+		`banana`,
+	)
+
+	popped, _ := b.Pop()
+	fmt.Printf("%T, length now: %d", popped, b.Len())
+	// Output: string, length now: 3
+}
+
+func ExampleStack_Pop_fIFO() {
+	b := Basic()
+	b.SetFIFO(true)
+	b.Push(
+		float64(3.14159),
+		float32(-9.378),
+		-1,
+		`banana`,
+	)
+
+	popped, _ := b.Pop()
+	fmt.Printf("%T, length now: %d", popped, b.Len())
+	// Output: float64, length now: 3
+}
+
 /*
 This example demonstrates the creation of a basic stack
 and an enforced capacity constraint.

--- a/stack_test.go
+++ b/stack_test.go
@@ -1023,6 +1023,7 @@ func TestDefrag_experimental_001(t *testing.T) {
 }
 
 func init() {
+	// just used for testing, etc.
 	//SetDefaultStackLogger(`stdout`)
 	//SetDefaultConditionLogger(`stdout`)
 }


### PR DESCRIPTION
## v0.0.3-alpha.1 dev notes

- Added preliminary **FIFO** (First-In-First-Out, a.k.a.: queue) support option, which complements the default **LIFO** (Last-In-Last-Out, a.k.a.: stack) behavior observed through use of the `Stack.Pop` method
  - For those unfamiliar with these concepts:
    -  **FIFO** is akin to the line at the deli: first come, first serve. In technical terms, this means the first slice (#0) shall be removed when `Stack.Pop` is executed in this operating mode
    -  **LIFO** is akin to a stack of plates in a box: last one in is at the top. In technical terms, this means the last slice (i.e.: `length -1`) shall be removed when `Stack.Pop` is executed in this operating mode
  - Users may execute `Stack.SetFIFO(true)` to invoke **FIFO** append/truncate behavior
  - Users should not change the scheme in effect once [de-]population has commenced during its lifespan
- Added `Stack.Reveal` method to recursively walk a `Stack` instance and disenvelop _needlessly_ nested elements
  - Abstract example: `And[And[And[1x Condition]]]`
  - `Stack`-in-`Condition` scenarios will be included in this operation
  - For the moment, `Not` stacks are exempt from this control due to their inverse nature
- Added `Stack.Defrag` method to recursively correct contiguity "errors" (i.e.: gaps)
  - The method will scan the receiver instance and implode, or "collapse", the slices such that no `nil` instances exist between non-`nil` slices
  - When complete, the trailing `nil` sequence is truncated entirely (else the receiver length would have remained constant)
  - A genuine need for this method would likely be rare and _quite_ unusual -- but not impossible
  - `Stack`-in-`Condition` scenarios will be included in this operation, as will `Stack`-in-`Stack` scenarios
- Decommissioned old `chan`-based event system in favor of basic `*log.Logger` functionality
  - Standard `*log.Logger` incarnations (e.g.: `stderr`, `stdout`) are available globally or per `Condition`/`Stack`
  - Custom `*log.Logger` instances may be provided by the user
  - Default logging state is to discard all log events using `io.Discard`, as is recommended
  - Included convenient LogLevel bit identifiers, allowing numerous verbosity-level permutations
  - Included ten (1) unnamed and reserved LogLevel bit identifiers for user customization
- Implemented `Interface` interface
  - Useful in situations where reduced type-assertion for `Condition` and `Stack` instances (or any qualifying aliased counterparts) would be appreciated by the end-user (this sentiment would apply **in particular** to extremely complex, nested structures).
  - The `Interface` interface only offers functionality that is inherently read-only, and only extends a subset of similar such methods that are common to both of the above root types in both name and signature
- Added/enhanced `Len` method support for `Condition` instances, the semantics of which are as follows:
  - If receiver is not initialized, or if no expression has been set, a length of zero (0) is returned
  - If receiver contains an expression that is a `Stack` (or alias of same) instance, its own `Len()` semantics apply and may return any integer (even zero (0))
  - A length of one (1) is returned as a fallback, representing the abstract length of a single `Condition`
- Added `Addr` method for both `Condition` and `Stack` type instances
  - This performs a crude internal call to `fmt.Sprintf` using the `%p` verb to print the memory address currently occupied by the underlying embedded instance
  - Mainly useful for unit tests, debugging or troubleshooting
  - Users who do not label their objects may find this mildly useful in some scenarios
- Added `SetID` method functionality to allow the (very) basic randomized generation of twenty-four (24) alphanumeric characters for convenient automatic naming of objects; this is triggered by the input of `_random` for an ID to set
  - `math/rand` is used, as this is not a security-sensitive feature
  - Similarly, `_addr` will automatically invoke the `Addr` method for the convenient naming of objects
- Added more traditional error handling support for `Stack` and `Condition` types, without sacrificing the fluent method signature design
  - `Stack` and `Condition` types now extends the `Err() error` method to allow the commonplace `if err != nil`-style checks for users who prefer that over the act of chaining fluent method calls that may obscure a particular problem's true source
  - Conversely, the `SetErr(err error) <fluent return type>` has been added to allow users to specify their own error conditions, when needed, or to **un**set an error instance already present within the receiver
- Misc. changes
  - Documentation improvements, typo corrections
  - Updated bullet-point documentation blocks to reflect the newer `pkgsite` syntax, thus avoiding the double-spaced lines between line-items that have plagued Gophers since the days of Godoc
- Misc. bug fixes
  - Corrected issue with `Stack.Cap` not returning the correct user-facing integer value
    - This did not impact the _actual_ capacity -- only the expected number of slices were permitted for addition; no more and no less than that
    - The offset for the 'hidden' configuration slice was not reflected during _interrogation procedures_, thus a capacity of four (4) would return five (5) when `Stack.Cap` was executed
  - Corrected issue with `Condition` type conversion attempts failed due to incorrect control type defined
  - Corrected inconsistent pointer usage for `Condition` method signatures (`Init` is now the _only_ `*Condition` signature bearer, as it should be)
  - Corrected issue where `Condition.SetExpression` was setting the native type instance of an assertion value, as opposed to the actual assertion value. For example:
    - User Bob submits type-aliased `stackage.Stack` instance -- let's say `main.MyStack` -- to a newly assembled `stackage.Condition` instance using its `SetExpression` method
    - The internal methods that evaluate the submitted assertion value will, at some point, check to see if the type instance is either a native `stackage.Stack` OR a type alias of same
    - In Bob's case, this check evaluted as true and the value was accepted
    - Unfortunately, the value that was actually written was the return value of an internal "alias->stack" converter; this should have been shadowed, and not used, as the process merely should look to see IF the assertion value is a `stackage.Stack`, but not actually use the converted value
    - The solution was simply to use the originally submitted value, as-is, once it passed the requisite checks
  - Corrected needlessly-padded `Stack.Kind` return value
    - Padding was originally applied to this value for string representation requests which contained one (1) or more Boolean WORD-based logical sequences (e.g.: `value AND othervalue`)
    - WORD operators should **always** have padding; SYMBOL operators may, or may not, have padding
    - Padding is now applied as expected, but is limited to operation within the `String()` methods, and no longer influences its component values directly outside of this scenario
    - Users and applications that were previously trimming the `Stack.Kind()` return value (e.g.: `strings.TrimSpace(myStack.Kind())`) may cease doing so at their leisure